### PR TITLE
doc: add getinfo command

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -18,11 +18,11 @@ Display general information about the current daemon state.
 
 #### Response
 
-| Field         | Type    | Description                                  |
-| ------------- | ------- | -------------------------------------------- |
-| `blockheight` | integer | Current block height                         |
-| `network`     | string  | Answer can be `mainnet`, `testnet`, `simnet` |
-| `version`     | string  | Version following the SimVer format          |
+| Field         | Type    | Description                                                   |
+| ------------- | ------- | ------------------------------------------------------------- |
+| `blockheight` | integer | Current block height                                          |
+| `network`     | string  | Answer can be `mainnet`, `testnet`, `regtest`                 |
+| `version`     | string  | Version following the [SimVer](http://www.simver.org/) format |
 
 ## Vault
 


### PR DESCRIPTION
 Should this command display also:
- a list of all hardware wallet connected to the daemon
- a list of metrics about the vaults
- an overview of the connected peers (wt etc)

or is it simpler to separate in different commands ?