### PR TITLE
Make the bitcoind poll interval an optional config option

### DIFF
--- a/contrib/config_regtest.toml
+++ b/contrib/config_regtest.toml
@@ -33,6 +33,7 @@ unvault_csv = 18
 network = "regtest"
 cookie_path = "/home/darosior/projects/revault/d/regtest/bcdir1/regtest/.cookie"
 addr = "127.0.0.1:9001"
+poll_interval_secs = 3
 
 # We are one of the below stakeholders
 [stakeholder_config]

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::PathBuf, vec::Vec};
+use std::{net::SocketAddr, path::PathBuf, time::Duration, vec::Vec};
 
 use revault_net::noise::PublicKey as NoisePubKey;
 use revault_tx::{
@@ -64,6 +64,26 @@ pub struct BitcoindConfig {
     pub cookie_path: PathBuf,
     /// The IP:port bitcoind's RPC is listening on
     pub addr: SocketAddr,
+    /// The poll interval for bitcoind
+    #[serde(with = "deser_duration", default = "default_poll_interval")]
+    pub poll_interval_secs: Duration,
+}
+
+mod deser_duration {
+    use serde::{self, Deserialize, Deserializer};
+    use std::time::Duration;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let secs = u64::deserialize(deserializer)?;
+        Ok(Duration::from_secs(secs))
+    }
+}
+
+fn default_poll_interval() -> Duration {
+    Duration::from_secs(30)
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -278,6 +298,7 @@ mod tests {
             network = "bitcoin"
             cookie_path = "/home/user/.bitcoin/.cookie"
             addr = "127.0.0.1:8332"
+            poll_interval_secs = 18
 
             # We are one of the above stakeholders
             [stakeholder_config]
@@ -318,6 +339,7 @@ mod tests {
             network = "bitcoin"
             cookie_path = "/home/user/.bitcoin/.cookie"
             addr = "127.0.0.1:8332"
+            poll_interval_secs = 4
 
             # We are one of the above managers
             [manager_config]
@@ -357,6 +379,7 @@ mod tests {
             network = "bitcoin"
             cookie_path = "/home/user/.bitcoin/.cookie"
             addr = "127.0.0.1:8332"
+            poll_interval_secs = 12
 
             # We are one of the above managers
             [manager_config]

--- a/src/daemon/bitcoind/actions.rs
+++ b/src/daemon/bitcoind/actions.rs
@@ -623,10 +623,7 @@ fn poller_main(
     // We use a cache for maintaining our deposits' state up-to-date by polling `listunspent`
     let mut deposits_cache = populate_deposit_cache(&revaultd.read().unwrap())?;
     // When bitcoind is synced, we poll each 30s. On regtest we speed it up for testing.
-    let poll_interval = match revaultd.read().unwrap().bitcoind_config.network {
-        Network::Regtest => Duration::from_secs(3),
-        _ => Duration::from_secs(30),
-    };
+    let poll_interval = revaultd.read().unwrap().bitcoind_config.poll_interval_secs;
 
     while !shutdown.load(Ordering::Relaxed) {
         let now = Instant::now();

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -8,30 +8,6 @@ from fixtures import *
 from utils import POSTGRES_IS_SETUP, TIMEOUT, RpcError, wait_for
 
 
-def test_revaultd_stakeholder_starts(revaultd_stakeholder):
-    revaultd_stakeholder.rpc.call("stop")
-    revaultd_stakeholder.wait_for_logs(
-        [
-            "Stopping revaultd.",
-            "Bitcoind received shutdown.",
-            "Signature fetcher thread received shutdown.",
-        ]
-    )
-    revaultd_stakeholder.proc.wait(TIMEOUT)
-
-
-def test_revaultd_manager_starts(revaultd_manager):
-    revaultd_manager.rpc.call("stop")
-    revaultd_manager.wait_for_logs(
-        [
-            "Stopping revaultd.",
-            "Bitcoind received shutdown.",
-            "Signature fetcher thread received shutdown.",
-        ]
-    )
-    revaultd_manager.proc.wait(TIMEOUT)
-
-
 def test_getinfo(revaultd_manager, bitcoind):
     res = revaultd_manager.rpc.call("getinfo")
     assert res["network"] == "regtest"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -703,6 +703,7 @@ class Revaultd(TailableProc):
             f.write(f'network = "regtest"\n')
             f.write(f"cookie_path = '{bitcoind_cookie}'\n")
             f.write(f"addr = '127.0.0.1:{bitcoind.rpcport}'\n")
+            f.write(f"poll_interval_secs = 3\n")
 
             if stk_config is not None:
                 f.write("[stakeholder_config]\n")


### PR DESCRIPTION
Add an optional conf option to specify the bitcoind interval.
If not specified, the interval defaults to 3 seconds in regtest
and 30 seconds in mainnet.

Signed-off-by: Daniela Brozzoni <danielabrozzoni@protonmail.com>

Fixes #73 