### PR TITLE
Spend transaction creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,14 +132,13 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if",
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -204,19 +203,6 @@ name = "futures"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
-
-[[package]]
-name = "generator"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "winapi",
-]
 
 [[package]]
 name = "getrandom"
@@ -298,9 +284,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
 name = "libsodium-sys"
@@ -331,17 +317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "loom"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
 ]
 
 [[package]]
@@ -526,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "revault_tx"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c4d0bad2a5322a5e816a248b8c668304f28a2962a4218e4c73d6ff5fc115a6"
+checksum = "fa5ded7990dcc8b935cacde788394d71de4a06eb1b4fec4828b715490b0797b7"
 dependencies = [
  "base64",
  "bitcoinconsensus",
@@ -597,22 +572,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "secp256k1"
@@ -670,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",

--- a/contrib/config_regtest.toml
+++ b/contrib/config_regtest.toml
@@ -42,7 +42,7 @@ xpub = "xpub6CFH8m3bnUFXWXxKVQjMXqMiQWYRhcTeZCW1QghmkNeGkPFwADfFNt9JMuW38MnYVSAV
 watchtowers = [ { host = "127.0.0.1:1", noise_key = "46084f8a7da40ef7ffc38efa5af8a33a742b90f920885d17c533bb2a0b680cb3" } ]
 emergency_address = "bcrt1qewc2348370pgw8kjz8gy09z8xyh0d9fxde6nzamd3txc9gkmjqmq8m4cdq"
 
-#[manager_config]
+[manager_config]
 # xprvA1DDS2qX9vCdRxSJmFA6AJPQPKS32S5hiUpzi9Xot9hzN4z1g6ip5oKJWXUeQDn2W48vaSWYVLaypC1JztUcrx23kucEtFzyU8t5Ay7NrDD
-#xpub = "xpub6ECZqYNQzHkveSWmsGh6XSL8wMGXRtoZ5hkbWXwRSVEyEsKADe34dbdnMob1ZjUpd4TD7no1isnnvpQq9DchFes5DnHJ7JupSntZsKr7VbQ"
-#cosigners = [ { host = "127.0.0.1:1", noise_key = "087629614d227ff2b9ed5f2ce2eb7cd527d2d18f866b24009647251fce58de38" } ]
+xpub = "xpub6ECZqYNQzHkveSWmsGh6XSL8wMGXRtoZ5hkbWXwRSVEyEsKADe34dbdnMob1ZjUpd4TD7no1isnnvpQq9DchFes5DnHJ7JupSntZsKr7VbQ"
+cosigners = [ { host = "127.0.0.1:1", noise_key = "087629614d227ff2b9ed5f2ce2eb7cd527d2d18f866b24009647251fce58de38" } ]

--- a/doc/API.md
+++ b/doc/API.md
@@ -260,10 +260,17 @@ set of vaults to spend.
 | Parameter   | Type                 | Description                                                           |
 | ----------- | -------------------- | --------------------------------------------------------------------- |
 | `outpoints` | string array         | Vault deposit outpoints -- vaults must be [`active`](#vault-statuses) |
-| `output`    | map of string to int | Map of Bitcoin addresses to amount                                    |
+| `outputs`   | map of string to int | Map of Bitcoin addresses to amount                                    |
+| `feerate`   | int                  | Target feerate for the transaction                                    |
 
 Fee is deducted from the total amount of the vaults spent minus the total
 amount of the output.
+
+`feerate` is tolerated to end up 10% below the target, or above if we can't create a
+change output.
+
+Mind the addition of the CPFP output we do, which must be taken into account by the
+feerate.
 
 #### Response
 
@@ -316,7 +323,7 @@ amount of the output.
 HSM                  client                      revaultd
  +                      +                          +
  |                      |                          |
- |                      | +---listvaults secure--> |
+ |                      | +---listvaults active--> |
  |                      | <--------vaults--------+ |
  |                      |                          |
  |                      | +--getunvaulttx--------> |

--- a/src/daemon/bitcoind/actions.rs
+++ b/src/daemon/bitcoind/actions.rs
@@ -417,7 +417,6 @@ fn presigned_transactions(
             emer_address,
             revaultd.xpub_ctx(),
             revaultd.lock_time,
-            revaultd.unvault_csv,
         )?;
         Ok((unvault_tx, cancel_tx, Some(emer_tx), Some(unemer_tx)))
     } else {
@@ -428,7 +427,6 @@ fn presigned_transactions(
             &cpfp_descriptor,
             revaultd.xpub_ctx(),
             revaultd.lock_time,
-            revaultd.unvault_csv,
         )?;
         Ok((unvault_tx, cancel_tx, None, None))
     }

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import pytest
+import random
 import serializations
 
 from bitcoin.core import COIN
@@ -752,3 +753,127 @@ def test_reorged_deposit_status(revault_network, bitcoind):
     revault_network.start_wallets()
     for w in revault_network.stk_wallets + revault_network.man_wallets:
         w.wait_for_active_vaults([deposit])
+
+
+@pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
+def test_getspendtx(revault_network, bitcoind):
+    revault_network.deploy(2, 1)
+    man = revault_network.man_wallets[0]
+    amount = 32.67890
+    vault = revault_network.fund(amount)
+    deposit = f"{vault['txid']}:{vault['vout']}"
+
+    addr = bitcoind.rpc.getnewaddress()
+    spent_vaults = [deposit]
+    # 10k fees, 50k CPFP, 50k unvault CPFP + fees
+    destination = {addr: vault["amount"] - 10_000 - 50_000 - 50_000}
+    feerate = 2
+
+    revault_network.secure_vault(vault)
+
+    # If the vault isn't active, it'll fail
+    with pytest.raises(RpcError, match="Invalid vault status"):
+        man.rpc.getspendtx(spent_vaults, destination, feerate)
+
+    revault_network.activate_vault(vault)
+
+    # If we are not a manager, it'll fail
+    with pytest.raises(RpcError, match="This is a manager command"):
+        revault_network.stk_wallets[0].rpc.getspendtx(
+            spent_vaults, destination, feerate
+        )
+
+    # The amount was not enough to afford a change output, everything went to
+    # fees.
+    psbt = serializations.PSBT()
+    psbt.deserialize(man.rpc.getspendtx(spent_vaults, destination, feerate)["spend_tx"])
+    assert len(psbt.inputs) == 1 and len(psbt.outputs) == 2
+
+    # But if we decrease it enough, it'll create a change output
+    destinations = {addr: vault["amount"] - 10_000 - 50_000 - 50_000 - 1_000_000}
+    psbt = serializations.PSBT()
+    psbt.deserialize(
+        man.rpc.getspendtx(spent_vaults, destinations, feerate)["spend_tx"]
+    )
+    assert len(psbt.inputs) == 1 and len(psbt.outputs) == 3
+
+    # Asking for an impossible feerate will error
+    with pytest.raises(
+        RpcError,
+        match="Required feerate .* is significantly higher than actual feerate",
+    ):
+        man.rpc.getspendtx(spent_vaults, destinations, 100_000)
+
+    # We'll stubbornly refuse they shoot themselves in the foot
+    with pytest.raises(
+        RpcError,
+        match="Fees larger than 20000000 sats",
+    ):
+        destinations = {addr: vault["amount"] // 10}
+        man.rpc.getspendtx(spent_vaults, destinations, 100_000)
+
+    # We can spend many vaults
+    deposits = [deposit]
+    amounts = [vault["amount"]]
+    for _ in range(10):
+        amount = round(random.random() * 10 ** 8 % 50, 7)
+        vault = revault_network.fund(amount)
+        revault_network.secure_vault(vault)
+        revault_network.activate_vault(vault)
+
+        deposit = f"{vault['txid']}:{vault['vout']}"
+        amount_sat = vault["amount"]
+        deposits.append(deposit)
+        amounts.append(amount_sat)
+
+        # Note that it passes even with 100k/vb if you disable insane fees
+        # sanity checks :)
+        feerate = random.randint(1, 10_000)
+        # Overhead, P2WPKH, P2WSH, inputs, witnesses
+        tx_vbytes = 11 + 31 + 43 + (32 + 4 + 4 + 1) * len(deposits) + 99 * len(deposits)
+        sent_amount = (
+            sum(amounts)
+            - tx_vbytes * feerate  # fees
+            - 2 * 32 * tx_vbytes  # CPFP
+            - 30_000 * len(deposits)  # Unvault CPFP
+            # Overhead, P2WSH * 2, inputs + witnesses
+            - (11 + 43 * 2 + 91) * len(deposits) * 24  # Unvault fees (6sat/WU feerate)
+        )
+        destinations = {addr: sent_amount}
+        psbt = serializations.PSBT()
+        psbt.deserialize(
+            man.rpc.getspendtx(deposits, destinations, feerate)["spend_tx"]
+        )
+        assert (
+            len(psbt.inputs) == len(deposits) and len(psbt.outputs) == 2
+        ), "unexpected change output"
+
+    # And we can spend to many destinations
+    deposits = [deposit]
+    destinations = {}
+    for _ in range(10):
+        feerate = random.randint(1, 1_000)
+        destinations[bitcoind.rpc.getnewaddress()] = vault["amount"] // 20
+        psbt = serializations.PSBT()
+        psbt.deserialize(
+            man.rpc.getspendtx(deposits, destinations, feerate)["spend_tx"]
+        )
+        assert (
+            len(psbt.inputs) == len(deposits)
+            # destinations + CPFP + change
+            and len(psbt.outputs) == len(destinations.keys()) + 1 + 1
+        ), "expected a change output"
+
+    # And we can do both
+    deposits = []
+    destinations = {}
+    for vault in man.rpc.listvaults(["active"])["vaults"]:
+        deposits.append(f"{vault['txid']}:{vault['vout']}")
+        destinations[bitcoind.rpc.getnewaddress()] = vault["amount"] // 2
+    psbt = serializations.PSBT()
+    psbt.deserialize(man.rpc.getspendtx(deposits, destinations, feerate)["spend_tx"])
+    assert (
+        len(psbt.inputs) == len(deposits)
+        # destinations + CPFP + change
+        and len(psbt.outputs) == len(destinations.keys()) + 1 + 1
+    ), "expected a change output"


### PR DESCRIPTION
This implements `getspendtx`, the RPC command used to gather the Spend transaction given a set of `active` vaults and pairs of destination addresses and amounts.

The command was fixed to include a feerate, see commit messages for details.

Tried to be exhaustive with testing but amounts (and especially fee) calculus is tricky and a fresh look on this will do a lot of good. Don't hesitate to question and if you write tests during your review they are very welcome.