### PR TITLE
State tracking for Unvault and Spend transactions

### DIFF
--- a/src/daemon/bitcoind/actions.rs
+++ b/src/daemon/bitcoind/actions.rs
@@ -6,15 +6,17 @@ use crate::{
     database::{
         actions::{
             db_confirm_deposit, db_confirm_unvault, db_insert_new_unconfirmed_vault,
-            db_mark_broadcasted_spend, db_mark_spent_unvault, db_spend_unvault,
-            db_unconfirm_deposit_dbtx, db_unvault_deposit, db_update_deposit_index, db_update_tip,
+            db_mark_broadcasted_spend, db_mark_rebroadcastable_spend, db_mark_spent_unvault,
+            db_spend_unvault, db_unconfirm_deposit_dbtx, db_unconfirm_spend_dbtx,
+            db_unconfirm_unvault_dbtx, db_unvault_deposit, db_update_deposit_index, db_update_tip,
             db_update_tip_dbtx,
         },
         interface::{
             db_broadcastable_spend_transactions, db_deposits, db_exec, db_spending_vaults, db_tip,
-            db_unvault_from_deposit, db_unvaulted_vaults, db_vault_by_deposit, db_vaults_dbtx,
-            db_wallet,
+            db_unvault_dbtx, db_unvault_from_deposit, db_unvaulted_vaults, db_vault_by_deposit,
+            db_vaults_dbtx, db_wallet,
         },
+        schema::DbVault,
     },
     revaultd::{BlockchainTip, RevaultD, VaultStatus},
     threadmessages::{BitcoindMessageOut, WalletTransaction},
@@ -341,17 +343,41 @@ fn new_tip_event(
     Ok(())
 }
 
+fn unconfirm_vault(
+    db_tx: &rusqlite::Transaction,
+    vault: DbVault,
+    deposits_cache: &mut HashMap<OutPoint, UtxoInfo>,
+) -> Result<(), BitcoindError> {
+    // This will delete the presigned transactions, as well as the Spend tranactions
+    // spending this vault.
+    db_unconfirm_deposit_dbtx(db_tx, vault.id)?;
+    // For these states we still have the entry in the deposit cache.
+    if matches!(
+        vault.status,
+        VaultStatus::Funded | VaultStatus::Secured | VaultStatus::Active
+    ) {
+        deposits_cache
+            .get_mut(&vault.deposit_outpoint)
+            .expect("Db vault not in cache?")
+            .is_confirmed = false;
+    }
+
+    Ok(())
+}
+
 // Get our state up to date with bitcoind.
 // - Drop vaults which deposit is not confirmed anymore
 // - Drop presigned transactions if the vault is downgraded to 'unconfirmed'
-// - (TODO) Downgrade our state if necessary (if another transaction was reorg'ed out)
+// - Downgrade our state if necessary (if a transaction of the chain was reorg'ed out)
 //
 // Note that we want this operation to be atomic: we don't want to be midly updating to the new
 // tip. Either we are updated to the new tip or we roll back to the previous one in case of error.
 fn comprehensive_rescan(
+    revaultd: &Arc<RwLock<RevaultD>>,
     db_tx: &rusqlite::Transaction,
     bitcoind: &BitcoinD,
     deposits_cache: &mut HashMap<OutPoint, UtxoInfo>,
+    unvaults_cache: &mut HashMap<OutPoint, UtxoInfo>,
 ) -> Result<(), BitcoindError> {
     log::info!("Starting rescan of all vaults in db..");
     let mut vaults = db_vaults_dbtx(&db_tx)?;
@@ -379,57 +405,155 @@ fn comprehensive_rescan(
 
         // bitcoind's wallet will always keep track of our transaction, even in case of reorg.
         let (_, blockheight, _) = bitcoind.get_wallet_transaction(&vault.deposit_outpoint.txid)?;
-        if let Some(height) = blockheight {
-            // Edge case: what if our tip is actually not up to date anymore
-            if height > tip.height {
-                return comprehensive_rescan(db_tx, bitcoind, deposits_cache);
-            }
-
-            let deposit_conf = tip.height.checked_sub(height).expect("Checked above") + 1;
-            if deposit_conf < MIN_CONF as u32 {
-                db_unconfirm_deposit_dbtx(db_tx, vault.id)?;
-                deposits_cache
-                    .get_mut(&vault.deposit_outpoint)
-                    .expect("Db vault not in cache?")
-                    .is_confirmed = false;
-                log::warn!(
-                    "Vault deposit '{}' ended up with '{}' confirmations (<{}), \
-                     marked as unconfirmed",
-                    vault.deposit_outpoint,
-                    deposit_conf,
-                    MIN_CONF,
-                );
-                continue;
-            }
-
-            // TODO: if secured, active, unvaulted, spent, emergencied check each transaction.
-
-            log::debug!(
-                "Vault deposit '{}' still has '{}' confirmations (>={}), not doing anything",
-                vault.deposit_outpoint,
-                deposit_conf,
-                MIN_CONF
-            );
+        let dep_height = if let Some(height) = blockheight {
+            height
         } else {
-            db_unconfirm_deposit_dbtx(db_tx, vault.id)?;
-            deposits_cache
-                .get_mut(&vault.deposit_outpoint)
-                .expect("Db vault not in cache?")
-                .is_confirmed = false;
+            unconfirm_vault(db_tx, vault, deposits_cache)?;
             log::warn!(
                 "Vault deposit '{}' ended up without confirmation, marked as \
                  unconfirmed",
                 vault.deposit_outpoint
             );
+            continue;
+        };
+
+        // Edge case: what if our tip is actually not up to date anymore
+        if dep_height > tip.height {
+            return comprehensive_rescan(revaultd, db_tx, bitcoind, deposits_cache, unvaults_cache);
+        }
+
+        // First layer: if the deposit itself becomes unconfirmed, no need to go further: mark the
+        // vault as unconfirmed and be done.
+        let deposit_conf = tip.height.checked_sub(dep_height).expect("Checked above") + 1;
+        if deposit_conf < MIN_CONF as u32 {
+            unconfirm_vault(db_tx, vault, deposits_cache)?;
+            log::warn!(
+                "Vault deposit '{}' ended up with '{}' confirmations (<{}), \
+                     marked as unconfirmed",
+                vault.deposit_outpoint,
+                deposit_conf,
+                MIN_CONF,
+            );
+
+            continue;
+        }
+
+        log::debug!(
+            "Vault deposit '{}' still has '{}' confirmations (>={}), not doing anything",
+            vault.deposit_outpoint,
+            deposit_conf,
+            MIN_CONF
+        );
+
+        // Second layer: if the Unvault was confirmed and becomes unconfirmed, we mark it as such
+        // and make such to rebroadcast the transaction that were depending on it.
+        if matches!(
+            vault.status,
+            VaultStatus::Unvaulted
+                | VaultStatus::Spending
+                | VaultStatus::Spent
+                | VaultStatus::Canceling
+                | VaultStatus::Canceled
+                | VaultStatus::UnvaultEmergencyVaulting
+                | VaultStatus::UnvaultEmergencyVaulted
+        ) {
+            let unvault_tx = db_unvault_dbtx(db_tx, vault.id)?.ok_or_else(|| {
+                BitcoindError::Custom(format!(
+                    "Vault '{}' has status '{}' but no Unvault in database!",
+                    vault.deposit_outpoint, vault.status
+                ))
+            })?;
+            let unvault_txid = unvault_tx.inner_tx().global.unsigned_tx.txid();
+            let (_, blockheight, _) = bitcoind.get_wallet_transaction(&unvault_txid)?;
+
+            let unv_height = if let Some(height) = blockheight {
+                height
+            } else {
+                // First and foremost, mark it as unconfirmed in the db
+                db_unconfirm_unvault_dbtx(db_tx, vault.id)?;
+
+                // Then either repopulate the cache (we remove the entry on spend) or update the
+                // cache accordingly.
+                let unvault_descriptor = revaultd
+                    .read()
+                    .unwrap()
+                    .unvault_descriptor
+                    .derive(vault.derivation_index);
+                let unvault_txin = unvault_tx
+                    .revault_unvault_txin(&unvault_descriptor, revaultd.read().unwrap().xpub_ctx());
+                let unvault_outpoint = unvault_txin.outpoint();
+                let txo = unvault_txin.into_txout().into_txout();
+                if matches!(vault.status, VaultStatus::Spent | VaultStatus::Spending) {
+                    db_mark_rebroadcastable_spend(db_tx, &unvault_txid)?;
+                    unvaults_cache.insert(
+                        unvault_outpoint,
+                        UtxoInfo {
+                            txo,
+                            is_confirmed: false,
+                        },
+                    );
+                } else if matches!(vault.status, VaultStatus::Unvaulted) {
+                    unvaults_cache
+                        .get_mut(&unvault_outpoint)
+                        .expect("Db unvault not in cache for 'unvaulted'?")
+                        .is_confirmed = false;
+                }
+
+                // For some reasons bitcoind's wallet may need a small kick-in
+                if revaultd.read().unwrap().is_manager() {
+                    match bitcoind.rebroadcast_wallet_tx(&unvault_txid) {
+                        Ok(()) => {}
+                        Err(e) => log::debug!(
+                            "Error re-broadcasting Unvault tx '{}': '{}'",
+                            unvault_txid,
+                            e
+                        ),
+                    }
+                }
+
+                // And finally hook the tests (and the eyeballs)
+                log::debug!(
+                    "Vault {}'s Unvault transaction {} got unconfirmed.",
+                    vault.deposit_outpoint,
+                    unvault_txid
+                );
+
+                continue;
+            };
+
+            log::debug!(
+                "Vault {}'s Unvault transaction is still confirmed (height '{}')",
+                vault.deposit_outpoint,
+                unv_height
+            );
+
+            // Third layer: if the Spend transaction *only* was confirmed and becomes unconfirmed,
+            // we just mark it as such. The bitcoind wallet will take care of the rebroadcast.
+            if matches!(vault.status, VaultStatus::Spent) {
+                let spend_txid = &vault.spend_txid.expect("Must be Some in 'spent'");
+                let (_, blockheight, _) = bitcoind.get_wallet_transaction(spend_txid)?;
+                if let Some(height) = blockheight {
+                    log::debug!(
+                        "Vault {}'s Spend transaction is still confirmed (height '{}')",
+                        vault.deposit_outpoint,
+                        height
+                    );
+                } else {
+                    db_unconfirm_spend_dbtx(db_tx, vault.id)?;
+                    log::debug!(
+                        "Vault {}'s Spend transaction {} got unconfirmed.",
+                        vault.deposit_outpoint,
+                        spend_txid
+                    );
+                    continue;
+                }
+            }
+
+            // TODO: First Emergency
         }
     }
 
     db_update_tip_dbtx(db_tx, &tip)?;
-    log::info!(
-        "\n\nCurrent vaults: {:?}\n Current cache: {:?}\n\n",
-        db_vaults_dbtx(db_tx),
-        &deposits_cache
-    );
 
     Ok(())
 }
@@ -437,18 +561,19 @@ fn comprehensive_rescan(
 // Check the latest tip, if it does not change or moves forward just do nothing or
 // update in in the database. However if it goes backward or the tip block hash changes
 // resynchronize ourself with the Bitcoin network.
-// Returns the new deposit cache up-to-date with the database
+// Returns the previous tip.
 fn update_tip(
     revaultd: &mut Arc<RwLock<RevaultD>>,
     bitcoind: &BitcoinD,
     deposits_cache: &mut HashMap<OutPoint, UtxoInfo>,
-) -> Result<(), BitcoindError> {
+    unvaults_cache: &mut HashMap<OutPoint, UtxoInfo>,
+) -> Result<BlockchainTip, BitcoindError> {
     let current_tip = db_tip(&revaultd.read().unwrap().db_file())?;
     let tip = bitcoind.get_tip()?;
 
     // Nothing changed, shortcut.
     if tip == current_tip {
-        return Ok(());
+        return Ok(tip);
     }
 
     if tip.height > current_tip.height {
@@ -456,7 +581,8 @@ fn update_tip(
         let bit_curr_hash = bitcoind.getblockhash(current_tip.height)?;
         if bit_curr_hash == current_tip.hash || current_tip.height == 0 {
             // We moved forward, everything is fine.
-            return new_tip_event(&revaultd, bitcoind, &tip);
+            new_tip_event(&revaultd, bitcoind, &tip)?;
+            return Ok(current_tip);
         }
     }
 
@@ -466,15 +592,16 @@ fn update_tip(
         &tip
     );
     db_exec(&revaultd.read().unwrap().db_file(), |db_tx| {
-        comprehensive_rescan(db_tx, bitcoind, deposits_cache).unwrap_or_else(|e| {
-            log::error!("Error while rescaning vaults: '{}'", e);
-            std::process::exit(1);
-        });
+        comprehensive_rescan(revaultd, db_tx, bitcoind, deposits_cache, unvaults_cache)
+            .unwrap_or_else(|e| {
+                log::error!("Error while rescaning vaults: '{}'", e);
+                std::process::exit(1);
+            });
         Ok(())
     })?;
     log::info!("Rescan of all vaults in db done.");
 
-    Ok(())
+    Ok(current_tip)
 }
 
 // Get fresh to-be-presigned transactions for this deposit utxo
@@ -641,6 +768,7 @@ fn update_utxos(
     bitcoind: &BitcoinD,
     deposits_cache: &mut HashMap<OutPoint, UtxoInfo>,
     unvaults_cache: &mut HashMap<OutPoint, UtxoInfo>,
+    previous_tip: &BlockchainTip,
 ) -> Result<(), BitcoindError> {
     let db_path = revaultd.read().unwrap().db_file();
 
@@ -673,9 +801,8 @@ fn update_utxos(
     for (outpoint, _) in spent_unvaults {
         // TODO: detect if it was spent by a Cancel or Emergency transaction before considering it
         // a Spend transaction.
-        let tip = db_tip(&revaultd.read().unwrap().db_file())?;
         let spend_txid = bitcoind
-            .get_spender_txid(&outpoint, &tip.hash)?
+            .get_spender_txid(&outpoint, &previous_tip.hash)?
             .ok_or_else(|| {
                 BitcoindError::Custom(format!(
                     "No spending transaction in wallet for Unvault '{}', but it *is* being spent",
@@ -891,16 +1018,18 @@ fn poller_main(
         }
 
         last_poll = Some(now);
-        update_tip(
+        let previous_tip = update_tip(
             &mut revaultd,
             &bitcoind.read().unwrap(),
             &mut deposits_cache,
+            &mut unvaults_cache,
         )?;
         update_utxos(
             &mut revaultd,
             &bitcoind.read().unwrap(),
             &mut deposits_cache,
             &mut unvaults_cache,
+            &previous_tip,
         )?;
     }
 

--- a/src/daemon/bitcoind/actions.rs
+++ b/src/daemon/bitcoind/actions.rs
@@ -387,18 +387,18 @@ fn comprehensive_rescan(
 
             let deposit_conf = tip.height.checked_sub(height).expect("Checked above") + 1;
             if deposit_conf < MIN_CONF as u32 {
-                log::warn!(
-                    "Vault deposit '{}' ended up with '{}' confirmations (<{}), \
-                     marking as unconfirmed",
-                    vault.deposit_outpoint,
-                    deposit_conf,
-                    MIN_CONF,
-                );
                 db_unconfirm_deposit_dbtx(db_tx, vault.id)?;
                 deposits_cache
                     .get_mut(&vault.deposit_outpoint)
                     .expect("Db vault not in cache?")
                     .is_confirmed = false;
+                log::warn!(
+                    "Vault deposit '{}' ended up with '{}' confirmations (<{}), \
+                     marked as unconfirmed",
+                    vault.deposit_outpoint,
+                    deposit_conf,
+                    MIN_CONF,
+                );
                 continue;
             }
 
@@ -411,16 +411,16 @@ fn comprehensive_rescan(
                 MIN_CONF
             );
         } else {
-            log::warn!(
-                "Vault deposit '{}' ended up without confirmation, marking as \
-                 unconfirmed",
-                vault.deposit_outpoint
-            );
             db_unconfirm_deposit_dbtx(db_tx, vault.id)?;
             deposits_cache
                 .get_mut(&vault.deposit_outpoint)
                 .expect("Db vault not in cache?")
                 .is_confirmed = false;
+            log::warn!(
+                "Vault deposit '{}' ended up without confirmation, marked as \
+                 unconfirmed",
+                vault.deposit_outpoint
+            );
         }
     }
 

--- a/src/daemon/bitcoind/actions.rs
+++ b/src/daemon/bitcoind/actions.rs
@@ -537,7 +537,6 @@ fn update_deposits(
                 .unwrap()
                 .wallet_id
                 .expect("Wallet id is set at startup in setup_db()"),
-            &utxo.status,
             &outpoint,
             &amount,
             derivation_index,

--- a/src/daemon/bitcoind/interface.rs
+++ b/src/daemon/bitcoind/interface.rs
@@ -584,6 +584,14 @@ impl BitcoinD {
             .map(|_| ())
     }
 
+    /// Broadcast a transaction that is already part of the wallet
+    pub fn rebroadcast_wallet_tx(&self, txid: &Txid) -> Result<(), BitcoindError> {
+        let (hex, _, _) = self.get_wallet_transaction(txid)?;
+        log::debug!("Re-broadcasting '{}'", hex);
+        self.make_watchonly_request("sendrawtransaction", &params!(Json::String(hex)))
+            .map(|_| ())
+    }
+
     /// So, bitcoind has no API for getting the transaction spending a wallet UTXO. Instead we are
     /// therefore using a rather convoluted way to get it the other way around, since the spending
     /// transaction is actually *part of the wallet transactions*.

--- a/src/daemon/database/schema.rs
+++ b/src/daemon/database/schema.rs
@@ -2,7 +2,7 @@ use crate::revaultd::VaultStatus;
 use revault_tx::{
     bitcoin::{
         util::bip32::{ChildNumber, ExtendedPubKey},
-        Amount, OutPoint,
+        Amount, OutPoint, Txid,
     },
     transactions::{
         CancelTransaction, EmergencyTransaction, SpendTransaction, UnvaultEmergencyTransaction,
@@ -41,6 +41,9 @@ CREATE TABLE wallets (
  * in which case the blockheight will be 0 (FIXME: should be NULL instead?).
  * For any vault entry a deposit transaction MUST be present in bitcoind's
  * wallet.
+ * The spend_txid is stored to not harass bitcoind trying to guess the spending
+ * txid out of a deposit outpoint. It MUST be NOT NULL if status is 'spending'
+ * or 'spent'.
  */
 CREATE TABLE vaults (
     id INTEGER PRIMARY KEY NOT NULL,
@@ -53,6 +56,7 @@ CREATE TABLE vaults (
     derivation_index INTEGER NOT NULL,
     received_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL,
+    spend_txid BLOB,
     FOREIGN KEY (wallet_id) REFERENCES wallets (id)
         ON UPDATE RESTRICT
         ON DELETE RESTRICT
@@ -134,6 +138,7 @@ pub struct DbVault {
     pub derivation_index: ChildNumber,
     pub received_at: u32,
     pub updated_at: u32,
+    pub spend_txid: Option<Txid>,
 }
 
 /// The type of the transaction, as stored in the "presigned_transactions" table

--- a/src/daemon/database/schema.rs
+++ b/src/daemon/database/schema.rs
@@ -93,7 +93,7 @@ CREATE TABLE spend_inputs (
         ON DELETE RESTRICT,
     FOREIGN KEY (spend_id) REFERENCES spend_transactions (id)
         ON UPDATE RESTRICT
-        ON DELETE RESTRICT
+        ON DELETE CASCADE
 );
 
 /* This stores Spend transactions we created. A txid column is there to

--- a/src/daemon/revaultd.rs
+++ b/src/daemon/revaultd.rs
@@ -39,7 +39,6 @@ use revault_tx::{
 pub enum VaultStatus {
     /// The deposit transaction has less than 6 confirmations
     Unconfirmed,
-    // FIXME: Do we assume "no reorgs > 6 blocks" ?
     /// The deposit transaction has more than 6 confirmations
     Funded,
     /// The emergency transaction is signed
@@ -63,8 +62,6 @@ pub enum VaultStatus {
     UnvaultEmergencyVaulting,
     /// The unvault emergency transactions is confirmed
     UnvaultEmergencyVaulted,
-    /// The unvault transaction CSV is expired
-    Spendable,
     /// The spend transaction has been broadcast
     Spending,
     // TODO: At what depth do we forget it ?
@@ -89,9 +86,8 @@ impl TryFrom<u32> for VaultStatus {
             9 => Ok(Self::EmergencyVaulted),
             10 => Ok(Self::UnvaultEmergencyVaulting),
             11 => Ok(Self::UnvaultEmergencyVaulted),
-            12 => Ok(Self::Spendable),
-            13 => Ok(Self::Spending),
-            14 => Ok(Self::Spent),
+            12 => Ok(Self::Spending),
+            13 => Ok(Self::Spent),
             _ => Err(()),
         }
     }
@@ -114,7 +110,6 @@ impl FromStr for VaultStatus {
             "emergencyvaulted" => Ok(Self::EmergencyVaulted),
             "unvaultermergencyvaulting" => Ok(Self::UnvaultEmergencyVaulting),
             "unvaultermergencyvaulted" => Ok(Self::UnvaultEmergencyVaulted),
-            "spendable" => Ok(Self::Spendable),
             "spending" => Ok(Self::Spending),
             "spent" => Ok(Self::Spent),
             _ => Err(()),
@@ -140,7 +135,6 @@ impl fmt::Display for VaultStatus {
                 Self::EmergencyVaulted => "emergencyvaulted",
                 Self::UnvaultEmergencyVaulting => "unvaultermergencyvaulting",
                 Self::UnvaultEmergencyVaulted => "unvaultermergencyvaulted",
-                Self::Spendable => "spendable",
                 Self::Spending => "spending",
                 Self::Spent => "spent",
             }

--- a/tests/test_framework/revault_network.py
+++ b/tests/test_framework/revault_network.py
@@ -4,6 +4,7 @@ import random
 
 from ephemeral_port_reserve import reserve
 from nacl.public import PrivateKey as Curve25519Private
+from test_framework import serializations
 from test_framework.coordinatord import Coordinatord
 from test_framework.cosignerd import Cosignerd
 from test_framework.revaultd import ManagerRevaultd, StakeholderRevaultd
@@ -34,6 +35,8 @@ class RevaultNetwork:
         self.stk_wallets = []
         self.man_wallets = []
 
+        self.csv = None
+
     def deploy(self, n_stakeholders, n_managers, csv=None):
         """
         Deploy a revault setup with {n_stakeholders} stakeholders, {n_managers}
@@ -43,6 +46,7 @@ class RevaultNetwork:
         if csv is None:
             # Not more than 6 months
             csv = random.randint(1, 26784)
+        self.csv = csv
 
         # FIXME: this is getting dirty.. We should re-centralize information
         # about each participant in specified data structures
@@ -272,6 +276,96 @@ class RevaultNetwork:
             stk.rpc.unvaulttx(deposit, unvault_psbt)
         for w in self.stk_wallets + self.man_wallets:
             w.wait_for_active_vaults([deposit])
+
+    def unvault_vaults(self, vaults, destinations, feerate):
+        """
+        Unvault these {vaults}, advertizing a Spend tx spending to these {destinations}
+        (mapping of addresses to amounts)
+        """
+        man = self.man_wallets[0]
+        deposits = []
+        deriv_indexes = []
+        for v in vaults:
+            deposits.append(f"{v['txid']}:{v['vout']}")
+            deriv_indexes.append(v["derivation_index"])
+        man.wait_for_active_vaults(deposits)
+
+        spend_tx = man.rpc.getspendtx(deposits, destinations, feerate)["spend_tx"]
+        for man in self.man_wallets:
+            spend_tx = man.man_keychain.sign_spend_psbt(spend_tx, deriv_indexes)
+            man.rpc.updatespendtx(spend_tx)
+
+        spend_psbt = serializations.PSBT()
+        spend_psbt.deserialize(spend_tx)
+        spend_psbt.tx.calc_sha256()
+        man.rpc.setspendtx(spend_psbt.tx.hash)
+
+        for w in self.man_wallets + self.stk_wallets:
+            wait_for(
+                lambda: len(w.rpc.listvaults(["unvaulting"], deposits)["vaults"])
+                == len(deposits)
+            )
+        self.bitcoind.generate_block(1, wait_for_mempool=len(deposits))
+        for w in self.man_wallets + self.stk_wallets:
+            wait_for(
+                lambda: len(w.rpc.listvaults(["unvaulted"], deposits)["vaults"])
+                == len(deposits)
+            )
+
+        unvault_txs = [
+            txs["unvault"]
+            for txs in man.rpc.listonchaintransactions(deposits)["onchain_transactions"]
+        ]
+        assert all(unvtx["blockheight"] is not None for unvtx in unvault_txs)
+        return unvault_txs
+
+    def spend_vaults(self, vaults, destinations, feerate):
+        """Spend these {vaults} to these {destinations} (mapping of addresses to amounts)"""
+        man = self.man_wallets[0]
+        deposits = []
+        deriv_indexes = []
+        for v in vaults:
+            deposits.append(f"{v['txid']}:{v['vout']}")
+            deriv_indexes.append(v["derivation_index"])
+
+        for man in self.man_wallets:
+            man.wait_for_active_vaults(deposits)
+
+        spend_tx = man.rpc.getspendtx(deposits, destinations, feerate)["spend_tx"]
+        for man in self.man_wallets:
+            spend_tx = man.man_keychain.sign_spend_psbt(spend_tx, deriv_indexes)
+            man.rpc.updatespendtx(spend_tx)
+
+        spend_psbt = serializations.PSBT()
+        spend_psbt.deserialize(spend_tx)
+        spend_psbt.tx.calc_sha256()
+        man.rpc.setspendtx(spend_psbt.tx.hash)
+
+        self.bitcoind.generate_block(1, wait_for_mempool=len(deposits))
+        for w in self.man_wallets + self.stk_wallets:
+            wait_for(
+                lambda: len(w.rpc.listvaults(["unvaulted"], deposits)["vaults"])
+                == len(deposits)
+            )
+        self.bitcoind.generate_block(self.csv)
+        man.wait_for_log(
+            f"Succesfully broadcasted Spend tx '{spend_psbt.tx.hash}'",
+        )
+        self.bitcoind.generate_block(1, wait_for_mempool=[spend_psbt.tx.hash])
+        wait_for(
+            lambda: len(man.rpc.listvaults(["spent"], deposits)["vaults"])
+            == len(deposits)
+        )
+
+        return spend_psbt.tx.hash
+
+    def spend_vaults_anyhow(self, vaults):
+        """Spend these vaults to a random address for a maximum amount for a fixed feerate"""
+        addr = self.bitcoind.rpc.getnewaddress()
+        total_spent = sum(v["amount"] for v in vaults)
+        feerate = 2
+        fees = self.compute_spendtx_fees(feerate, len(vaults), 1)
+        return self.spend_vaults(vaults, {addr: total_spent - fees}, feerate)
 
     def compute_spendtx_fees(
         self, spendtx_feerate, n_vaults_spent, n_destinations, with_change=False

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -568,7 +568,6 @@ def test_revocation_sig_sharing(revault_network):
 
 
 def test_reorged_deposit(revaultd_stakeholder, bitcoind):
-    # TODO: start / stop, partial reorgs
     stk = revaultd_stakeholder
 
     # Create a new deposit
@@ -580,13 +579,9 @@ def test_reorged_deposit(revaultd_stakeholder, bitcoind):
     # Get it confirmed
     vault = stk.rpc.listvaults()["vaults"][0]
     deposit = f"{vault['txid']}:{vault['vout']}"
-    bitcoind.generate_block(6)
-
+    bitcoind.generate_block(6, wait_for_mempool=vault["txid"])
     stk.wait_for_deposits([deposit])
-    # FIXME: remove this ugly workaround once the blockheight is in `listvaults`
-    blockheight = stk.rpc.listonchaintransactions([deposit])["onchain_transactions"][0][
-        "deposit"
-    ]["blockheight"]
+    vault = stk.rpc.listvaults()["vaults"][0]
 
     # Now reorg the last block. This should not affect us, but we should detect
     # it.
@@ -601,7 +596,7 @@ def test_reorged_deposit(revaultd_stakeholder, bitcoind):
     stk.wait_for_deposits([deposit])
 
     # Now actually reorg the deposit. This should not affect us
-    bitcoind.simple_reorg(blockheight)
+    bitcoind.simple_reorg(vault["blockheight"])
     stk.wait_for_logs(
         [
             "Detected reorg",
@@ -614,7 +609,7 @@ def test_reorged_deposit(revaultd_stakeholder, bitcoind):
     # Now reorg the deposit and shift the transaction up 3 blocks, since we are
     # adding an extra one during the reorg we should still have 6 confs and be
     # fine
-    bitcoind.simple_reorg(blockheight, shift=3)
+    bitcoind.simple_reorg(vault["blockheight"], shift=3)
     stk.wait_for_logs(
         [
             "Detected reorg",
@@ -626,7 +621,7 @@ def test_reorged_deposit(revaultd_stakeholder, bitcoind):
     # Now reorg the deposit and shift the transaction up 2 blocks, since we are
     # adding an extra one during the reorg we should end up with 5 confs, and
     # mark the vault as unconfirmed
-    bitcoind.simple_reorg(blockheight + 3, shift=2)
+    bitcoind.simple_reorg(vault["blockheight"] + 3, shift=2)
     stk.wait_for_logs(
         [
             "Detected reorg",
@@ -638,7 +633,7 @@ def test_reorged_deposit(revaultd_stakeholder, bitcoind):
 
     # Reorg it again, it's already unconfirmed so nothing to do, but since we
     # mined a new block it's now confirmed!
-    bitcoind.simple_reorg(blockheight + 3 + 2)
+    bitcoind.simple_reorg(vault["blockheight"] + 3 + 2)
     stk.wait_for_logs(
         [
             "Detected reorg",
@@ -651,7 +646,7 @@ def test_reorged_deposit(revaultd_stakeholder, bitcoind):
 
     # Now try to completely evict it from the chain with a 6-blocks reorg. We
     # should mark it as unconfirmed (but it's not the same codepath).
-    bitcoind.simple_reorg(blockheight + 3 + 2, shift=-1)
+    bitcoind.simple_reorg(vault["blockheight"] + 3 + 2, shift=-1)
     stk.wait_for_logs(
         [
             "Detected reorg",
@@ -667,16 +662,11 @@ def test_reorged_deposit_status(revault_network, bitcoind):
     revault_network.deploy(4, 2)
     vault = revault_network.fund(0.14)
     revault_network.secure_vault(vault)
-
     deposit = f"{vault['txid']}:{vault['vout']}"
-    # FIXME: remove this ugly workaround once the blockheight is in `listvaults`
-    blockheight = revault_network.stk_wallets[0].rpc.listonchaintransactions([deposit])[
-        "onchain_transactions"
-    ][0]["deposit"]["blockheight"]
 
     # Reorg the deposit. This should not affect us as the transaction did not
     # shift
-    bitcoind.simple_reorg(blockheight)
+    bitcoind.simple_reorg(vault["blockheight"])
     for w in revault_network.stk_wallets + revault_network.man_wallets:
         w.wait_for_logs(
             [
@@ -687,7 +677,7 @@ def test_reorged_deposit_status(revault_network, bitcoind):
         )
 
     # Now actually shift it (7 + 1 - 3 == 5)
-    bitcoind.simple_reorg(blockheight, shift=3)
+    bitcoind.simple_reorg(vault["blockheight"], shift=3)
     for w in revault_network.stk_wallets + revault_network.man_wallets:
         w.wait_for_logs(
             [
@@ -712,7 +702,7 @@ def test_reorged_deposit_status(revault_network, bitcoind):
 
     # Now do the same dance with the 'active' status
     revault_network.activate_vault(vault)
-    bitcoind.simple_reorg(blockheight + 3)
+    bitcoind.simple_reorg(vault["blockheight"] + 3)
     for w in revault_network.stk_wallets + revault_network.man_wallets:
         w.wait_for_logs(
             [
@@ -721,7 +711,7 @@ def test_reorged_deposit_status(revault_network, bitcoind):
                 f"Vault deposit '{deposit}' still has '7' confirmations",
             ]
         )
-    bitcoind.simple_reorg(blockheight + 3, shift=3)
+    bitcoind.simple_reorg(vault["blockheight"] + 3, shift=3)
     for w in revault_network.stk_wallets + revault_network.man_wallets:
         w.wait_for_logs(
             [
@@ -737,7 +727,7 @@ def test_reorged_deposit_status(revault_network, bitcoind):
 
     # If we are stopped during the reorg, we recover in the same way at startup
     revault_network.stop_wallets()
-    bitcoind.simple_reorg(blockheight + 3 + 3)
+    bitcoind.simple_reorg(vault["blockheight"] + 3 + 3)
     revault_network.start_wallets()
     for w in revault_network.stk_wallets + revault_network.man_wallets:
         w.wait_for_logs(
@@ -749,7 +739,7 @@ def test_reorged_deposit_status(revault_network, bitcoind):
         )
 
     revault_network.stop_wallets()
-    bitcoind.simple_reorg(blockheight + 3 + 3, shift=3)
+    bitcoind.simple_reorg(vault["blockheight"] + 3 + 3, shift=3)
     revault_network.start_wallets()
     for w in revault_network.stk_wallets + revault_network.man_wallets:
         w.wait_for_logs(


### PR DESCRIPTION
This (for once is not based on another PR  and) makes us track the Unvault UTXOs pretty much in the same manner as we already track the deposits. This also features some small drive-by cleanups in the db, revaultd and reorg tests.

We try to not overload `bitcoind` with `listunspent` calls and therefore to track unconfirmed, confirmed and spent utxos in 3 mappings for each descriptor.
The idea for the state tracking is to treat our transaction chain as a tree and to only track the trunk's descriptors on the bitcoind watchonly wallet, then figure out the branches out of it:
```
                         -- Bypass
                     /
deposit utxos  --  Unvault
                     \  Emergency

                           Cancel
                     /        Emergency
unvault utxos     /
                     \ __  Spend
```

For Spend transaction, we use a bulky check similar to the broadcast: every new tip update we check if any new Spend transaction confirmed.