### PR TITLE
Test derived second stage transactions

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -140,11 +140,19 @@ vault's state).
 
 | Field               | Type                                                           | Description                                                              |
 | ------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `vault_outpoint`    | string                                                         | The vault deposit transaction outpoint.                                  |
-| `unvault`           | string                                                         | The unvaulting transaction as a base64-encoded PSBT                      |
-| `cancel`            | string                                                         | The cancel transaction as a base64-encoded PSBT                          |
-| `emergency`         | string or `null`                                               | The Emergency transaction, or `null` if we are not a stakeholder         |
-| `unvault_emergency` | string or `null`                                               | The Unvault Emergency transaction, or `null` if we are not a stakeholder |
+| `vault_outpoint`    | [presigned_tx](#presigned-tx)                                  | The vault deposit transaction outpoint.                                  |
+| `unvault`           | [presigned_tx](#presigned-tx)                                  | The Unvaulting transaction                                               |
+| `cancel`            | [presigned_tx](#presigned-tx)                                  | The Cancel transaction                                                   |
+| `emergency`         | [presigned_tx](#presigned-tx)                                  | The Emergency transaction, or `null` if we are not a stakeholder         |
+| `unvault_emergency` | [presigned_tx](#presigned-tx)                                  | The Unvault Emergency transaction, or `null` if we are not a stakeholder |
+
+
+#### Presigned tx
+
+| Field    | Type                     | Description                                                                      |
+| -------- | ------------------------ | -------------------------------------------------------------------------------- |
+| `psbt`   | string                   | The presigned transaction as a base64-encoded PSBT                               |
+| `hex`    | string or `null`         | If fully-signed, the presigned transaction as a hex-encoded Bitcoin transaction  |
 
 
 ### `listonchaintransactions`

--- a/src/daemon/jsonrpc/api.rs
+++ b/src/daemon/jsonrpc/api.rs
@@ -392,7 +392,7 @@ impl RpcApi for RpcImpl {
         assume_ok!(
             meta.tx.send(RpcMessageIn::ListPresignedTransactions(
                 outpoints,
-                response_tx
+                response_tx,
             )),
             "Sending 'listpresignedtransactions' to main thread"
         );

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -253,6 +253,24 @@ def test_listpresignedtransactions(revault_network):
         if res["unvault_emergency"] is not None:
             assert res["unvault_emergency"] == stk_res["unvault_emergency"]
 
+    # If the vault gets secured the extracted revocation transactions will be
+    # available
+    revault_network.secure_vault(vaultA)
+    stk_res = stks[0].rpc.listpresignedtransactions([depositA])[
+        "presigned_transactions"
+    ][0]
+    assert stk_res["unvault"]["hex"] is None, "not active yet"
+    assert stk_res["cancel"]["hex"] is not None
+    assert stk_res["emergency"]["hex"] is not None
+    assert stk_res["unvault_emergency"]["hex"] is not None
+
+    # If the vault gets activated the unvault transaction will then be available
+    revault_network.activate_vault(vaultA)
+    man_res = mans[0].rpc.listpresignedtransactions([depositA])[
+        "presigned_transactions"
+    ][0]
+    assert man_res["unvault"]["hex"] is not None
+
 
 @pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
 def test_listonchaintransactions(revault_network):
@@ -1637,7 +1655,7 @@ def test_revault(revault_network, bitcoind, executor):
     # First of all, we need the unvault psbt finalized
     unvault_psbt = stks[0].rpc.listpresignedtransactions([deposit])[
         "presigned_transactions"
-    ][0]["unvault"]
+    ][0]["unvault"]["psbt"]
     unvault_tx = bitcoind.rpc.finalizepsbt(unvault_psbt)["hex"]
     bitcoind.rpc.sendrawtransaction(unvault_tx)
 
@@ -1681,10 +1699,9 @@ def test_revault(revault_network, bitcoind, executor):
 
     for v in [vault_a, vault_b]:
         deposit = f"{v['txid']}:{v['vout']}"
-        unvault_psbt = man.rpc.listpresignedtransactions([deposit])[
+        unvault_tx = man.rpc.listpresignedtransactions([deposit])[
             "presigned_transactions"
-        ][0]["unvault"]
-        unvault_tx = bitcoind.rpc.finalizepsbt(unvault_psbt)["hex"]
+        ][0]["unvault"]["hex"]
         bitcoind.rpc.sendrawtransaction(unvault_tx)
 
         # On purpose, only wait for the one we want to revault with, to trigger some race conditions
@@ -1714,7 +1731,7 @@ def test_revault(revault_network, bitcoind, executor):
         cancel_psbt = serializations.PSBT()
         cancel_b64 = stks[0].rpc.listpresignedtransactions([deposit])[
             "presigned_transactions"
-        ][0]["cancel"]
+        ][0]["cancel"]["psbt"]
         cancel_psbt.deserialize(cancel_b64)
 
         cancel_psbt.tx.calc_sha256()


### PR DESCRIPTION
This adds a test to fix #147 . See commit messages, what we experienced was because `bitcoind` can't understand our Unvault Scripts.

Based on #156 