### PR TITLE
bitcoind: unload any leftover watchonly wallet at startup

### DIFF
--- a/src/daemon/bitcoind/interface.rs
+++ b/src/daemon/bitcoind/interface.rs
@@ -230,6 +230,25 @@ impl BitcoinD {
         )))
     }
 
+    pub fn unloadwallet(&self, wallet_path: String) -> Result<(), BitcoindError> {
+        let res = self.make_node_request("unloadwallet", &params!(Json::String(wallet_path),))?;
+
+        let warning = res
+            .get("warning")
+            .map(|w| w.as_str())
+            .flatten()
+            .ok_or_else(|| {
+                BitcoindError::Custom(
+                    "No or invalid 'warning' in 'unloadwallet' result".to_string(),
+                )
+            })?;
+        if warning.len() > 0 {
+            Err(BitcoindError::Custom(warning.to_string()))
+        } else {
+            Ok(())
+        }
+    }
+
     /// Constructs an `addr()` descriptor out of an address
     pub fn addr_descriptor(&self, address: &str) -> Result<String, BitcoindError> {
         let desc_wo_checksum = format!("addr({})", address);

--- a/src/daemon/bitcoind/interface.rs
+++ b/src/daemon/bitcoind/interface.rs
@@ -354,13 +354,13 @@ impl BitcoinD {
             "importdescriptors",
             &params!(Json::Array(vec![Json::Object(desc_map,)])),
         )?;
-        if res.get(0).map(|x| x.get("success")) == Some(Some(&Json::Bool(true))) {
+        if res.get(0).map(|x| x.get("success")).flatten() == Some(&Json::Bool(true)) {
             return Ok(());
         }
 
         Err(BitcoindError::Custom(format!(
-            "In import_fresh descriptor, error returned from 'importdescriptor': {:?}",
-            res.get("error")
+            "In import_fresh descriptor, no success returned from 'importdescriptor': {:?}",
+            res
         )))
     }
 


### PR DESCRIPTION
We used to have this check and i removed it since it does not seem right
for us to unload wallets on the host's bitcoind. But it's actually fine
if it's the very same one we create (by name) and we'll now also refuse
to start with an inconsistent number of loaded watchonly wallets.

Fixes #176 