### PR TITLE
Add filter to listspendtxs

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -338,8 +338,20 @@ disregarded for forward compatibility.
 
 #### Request
 
-| Field          | Type   | Description                                         |
-| -------------- | ------ | --------------------------------------------------- |
+| Field          | Type   | Description                                                          |
+| -------------- | ------ | -------------------------------------------------------------------- |
+| `status`       | array  | Array of [Spend status](#spend_status) |
+
+##### Spend status
+
+Please note that this status refers only to the Spend transaction, with regarding to the signatures and the broadcast status.
+You'll have to manually fetch the vaults statuses if you want to know, for example, if the vault was canceled or not.
+
+| Value           | Description                                                                                                                                                                              |
+| --------------- | ------------------------------------------------------------------------------------------------ |
+| `non_final`     | The Spend transaction is not final, we are awaiting signatures either from managers or cosigners |
+| `pending`       | The transaction is not broadcasted to the Bitcoin network                                        |
+| `broadcasted`   | The Spend transaction has been broadcasted                                                       |
 
 #### Response
 

--- a/src/daemon/control.rs
+++ b/src/daemon/control.rs
@@ -52,7 +52,7 @@ use std::{
     thread::JoinHandle,
 };
 
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 
 /// A presigned transaction
 #[derive(Debug, Serialize)]
@@ -124,6 +124,14 @@ where
     } else {
         s.serialize_none()
     }
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ListSpendStatus {
+    NonFinal,
+    Pending,
+    Broadcasted,
 }
 
 /// Any error that could arise during the process of executing the user's will.

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -731,6 +731,7 @@ pub fn db_mark_rebroadcastable_spend(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::database::schema::DbSpendTransaction;
     use crate::revaultd::RevaultD;
     use common::config::Config;
     use revault_tx::{
@@ -1240,7 +1241,14 @@ mod test {
         let spend_txid = spend_tx.txid();
         assert_eq!(
             db_list_spends(&db_path).unwrap().get(&spend_txid),
-            Some(&(spend_tx.clone(), vec![outpoint]))
+            Some(&(
+                DbSpendTransaction {
+                    id: 1,
+                    psbt: spend_tx.clone(),
+                    broadcasted: None
+                },
+                vec![outpoint]
+            ))
         );
 
         // We can update it, eg with a Spend with more sigs
@@ -1249,12 +1257,19 @@ mod test {
         let spend_txid = spend_tx.txid();
         assert_eq!(
             db_list_spends(&db_path).unwrap().get(&spend_txid),
-            Some(&(spend_tx.clone(), vec![outpoint]))
+            Some(&(
+                DbSpendTransaction {
+                    id: 1,
+                    psbt: spend_tx.clone(),
+                    broadcasted: None
+                },
+                vec![outpoint]
+            ))
         );
 
         // And delete it
         db_delete_spend(&db_path, &spend_tx.txid()).unwrap();
-        assert_eq!(db_list_spends(&db_path).unwrap().get(&spend_txid), None,);
+        assert!(db_list_spends(&db_path).unwrap().get(&spend_txid).is_none());
 
         // And this works with multiple unvaults too
 
@@ -1315,12 +1330,26 @@ mod test {
         let spend_txid = spend_tx.txid();
         assert_eq!(
             db_list_spends(&db_path).unwrap().get(&spend_txid),
-            Some(&(spend_tx.clone(), vec![outpoint]))
+            Some(&(
+                DbSpendTransaction {
+                    id: 1,
+                    psbt: spend_tx.clone(),
+                    broadcasted: None
+                },
+                vec![outpoint]
+            ))
         );
         let spend_txid_b = spend_tx_b.txid();
         assert_eq!(
             db_list_spends(&db_path).unwrap().get(&spend_txid_b),
-            Some(&(spend_tx_b.clone(), vec![outpoint, outpoint_b]))
+            Some(&(
+                DbSpendTransaction {
+                    id: 2,
+                    psbt: spend_tx_b.clone(),
+                    broadcasted: None
+                },
+                vec![outpoint, outpoint_b]
+            ))
         );
 
         let spend_tx_b = SpendTransaction::from_psbt_str("cHNidP8BAGcCAAAAAXHqOcTAJnPyXEF1cxFATe4S6yHLGZm+s0aj9mUTtKgVAAAAAACHGwAAAoAyAAAAAAAAIgAgAYLPNnsrzQaSg7aZR0JUgXHtO6bnZRehvxqxyzW5m5ygjAIAAAAAAAAAAAAAAAEBK0ANAwAAAAAAIgAgdS3fC7QX+PKWZBful8J229uixPOW012CYpKMH7rU8T4iAgKkxJmDMXYy1OdMI/x8PV9j3+1kQ0gpzuD+KqSeYfjzTkgwRQIhAMwdbbLXqH49pRfZR6PtSzNg/MB+DuVo1xs7rPTZQ12RAiBDSHEGyQaE1K+wknL2IFnhWXKn+/YSfSMtMg9u4zepNwEiAgO2p8sldVsHhhEimy+ZW0E1L3vX5d9mqQ0d01XVdx3DWUcwRAIgRhhHxuXx5X2eniy4tMP4wP2xoBD+XZlxMQiF9HoXIDYCIEfKdXOOILXSFKeOZ2v6nomllEQOyjuBUk+0LhK7+55mASICAtutlRTEdM0EvJJfteMEFrlq7FN+O5RIfETe8nUld92VSDBFAiEAzSxWF19m2/1Sh92jahJ/A6pMvmCa95USVSXzPEOBn3ACIHzYQdjjDJIhZ5z1xkduaEtjvYtLDIauoMA00xO6fok3AQEDBAEAAAABBaohAtutlRTEdM0EvJJfteMEFrlq7FN+O5RIfETe8nUld92VrFGHZHapFLyK7KRbyUNl1FZeArhRjSAsCSNfiKxrdqkUn6VDRhuPgSKDvf3VMS3GKSA/gMOIrGyTUodnUiECpMSZgzF2MtTnTCP8fD1fY9/tZENIKc7g/iqknmH4804hA7anyyV1WweGESKbL5lbQTUve9fl32apDR3TVdV3HcNZUq8ChxuyaAABASUhAtutlRTEdM0EvJJfteMEFrlq7FN+O5RIfETe8nUld92VrFGHAAA=").unwrap();

--- a/src/daemon/database/interface.rs
+++ b/src/daemon/database/interface.rs
@@ -633,9 +633,9 @@ impl TryFrom<&Row<'_>> for DbSpendTransaction {
 /// List all Spend transactions in DB along with the vault they are spending
 pub fn db_list_spends(
     db_path: &PathBuf,
-) -> Result<HashMap<Txid, (SpendTransaction, Vec<OutPoint>)>, DatabaseError> {
+) -> Result<HashMap<Txid, (DbSpendTransaction, Vec<OutPoint>)>, DatabaseError> {
     // SpendTransaction can't be Hash for the moment
-    let mut res: HashMap<Txid, (SpendTransaction, Vec<OutPoint>)> = HashMap::with_capacity(128);
+    let mut res: HashMap<Txid, (DbSpendTransaction, Vec<OutPoint>)> = HashMap::with_capacity(128);
 
     db_query(
         db_path,
@@ -652,14 +652,13 @@ pub fn db_list_spends(
             let vout: u32 = row.get(5)?;
             let deposit_outpoint = OutPoint { txid, vout };
 
-            let spend_tx = db_spend.psbt;
-            let spend_txid = spend_tx.inner_tx().global.unsigned_tx.txid();
+            let spend_txid = db_spend.psbt.inner_tx().global.unsigned_tx.txid();
 
             if res.contains_key(&spend_txid) {
                 let (_, outpoints) = res.get_mut(&spend_txid).unwrap();
                 outpoints.push(deposit_outpoint);
             } else {
-                res.insert(spend_txid, (spend_tx, vec![deposit_outpoint]));
+                res.insert(spend_txid, (db_spend, vec![deposit_outpoint]));
             }
 
             Ok(())

--- a/src/daemon/database/schema.rs
+++ b/src/daemon/database/schema.rs
@@ -218,7 +218,7 @@ pub struct DbSpendInput {
 }
 
 /// A row in the "spend_transactions" table
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct DbSpendTransaction {
     pub id: i64,
     pub psbt: SpendTransaction,


### PR DESCRIPTION
This PR adds a filter to the `listspendtx` call, meant to be used to improve the general UI/UX in the home screen. I propose to create three different sections in the home regarding spends:
1. Pending spends, which contains the spends which are awaiting signatures, and the ones not broadcasted yet (`final`, `non_final`)
2. Ongoing spends, which contains the spends we already knew, in the states `Unvaulting` `Unvaulted` `Spending` (they map to the status `Ongoing` and `Broadcasted` statuses in this PR. I left the `Ongoing` and `Broadcasted` statuses separated as they could be useful, but for the purpose of this PR I might as well merge them)
3. Unknown spends (or a better name), which contains the spends we didn't know, aka every vault in the state of `Unvaulting`, `Unvaulted`, `Spending`, but for which we didn't know the spend tx. This adds a little bit of complexity (what if we knew the spend, but a different one was broadcasted? How do we notice?) and I'm not really sure it can be made, but it would be cool to have.

Fixes #121