### PR TITLE
Basic (non hardened) Emergency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ the coins stored and may or may not own them) logic is part of this daemon.
 
 Please see [`doc/DEMO.md`](doc/DEMO.md) if you want a tutorial on how to do a deployment
 in regtest on Linux of revaultd.
-You can find more RPC commands at [`doc/API.md`](doc/API.md) but all aren't implemented
-yet!
+
+You can find a reference of available RPC commands at [`doc/API.md`](doc/API.md).
 
 See also the [functional tests](tests/) for a more complete integration (especially with
-the coordinator).
+the Coordinator and Cosigning Servers).
 
 # Contributing
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -21,6 +21,7 @@ Note that all addresses are bech32-encoded *version 0* native Segwit `scriptPubK
 | [`setspendtx`](#setspendtx)                                 | Announce and broadcast this Spend transaction        |
 | [`listspendtxs`](#listspendtxs)                             | List all stored Spend transactions                   |
 | [`gethistory`](#gethistory)                                 | Retrieve history of funds                            |
+| [`emergency`](#emergency)                                   | Broadcast all Emergency signed transactions          |
 
 
 
@@ -410,6 +411,20 @@ of inflows and outflows net of any change amount (that is technically a transact
 | `date`   | int    | Timestamp of the event                                                                   |
 | `amount` | int    | Absolute amount in satoshis that is entering or exiting the wallet                       |
 | `fee`    | int    | Fee of the event transaction                                                             |
+
+
+### `emergency`
+
+#### Request
+
+| Field          | Type   | Description                                    |
+| -------------- | ------ | ---------------------------------------------- |
+
+#### Response
+
+None; the `result` field will be set to the empty object `{}`. Any value should be
+disregarded for forward compatibility.
+
 
 ## User flows
 

--- a/src/daemon/bitcoind/actions.rs
+++ b/src/daemon/bitcoind/actions.rs
@@ -1696,13 +1696,13 @@ pub fn bitcoind_main_loop(
                         ))
                     })?;
             }
-            BitcoindMessageOut::BroadcastTransaction(tx, resp_tx) => {
-                log::trace!("Received 'broadcastransaction' from main thread");
+            BitcoindMessageOut::BroadcastTransactions(txs, resp_tx) => {
+                log::trace!("Received 'broadcastransactions' from main thread");
                 resp_tx
-                    .send(bitcoind.read().unwrap().broadcast_transaction(&tx))
+                    .send(bitcoind.read().unwrap().broadcast_transactions(&txs))
                     .map_err(|e| {
                         BitcoindError::Custom(format!(
-                            "Sending wallet transaction to main thread: {}",
+                            "Sending transactions broadcast result to main thread: {}",
                             e
                         ))
                     })?;

--- a/src/daemon/bitcoind/interface.rs
+++ b/src/daemon/bitcoind/interface.rs
@@ -704,6 +704,15 @@ impl BitcoinD {
             .map(|_| ())
     }
 
+    /// Broadcast a batch of transactions with 'sendrawtransaction'
+    pub fn broadcast_transactions(&self, txs: &[Transaction]) -> Result<(), BitcoindError> {
+        for tx in txs {
+            self.broadcast_transaction(&tx)?;
+        }
+
+        Ok(())
+    }
+
     /// Broadcast a transaction that is already part of the wallet
     pub fn rebroadcast_wallet_tx(&self, txid: &Txid) -> Result<(), BitcoindError> {
         let (hex, _, _) = self.get_wallet_transaction(txid)?;

--- a/src/daemon/bitcoind/mod.rs
+++ b/src/daemon/bitcoind/mod.rs
@@ -15,6 +15,8 @@ pub enum BitcoindError {
     Custom(String),
     /// Or directly to bitcoind's RPC server
     Server(Error),
+    /// They replied to a batch request omitting some responses
+    BatchMissingResponse,
     RevaultTx(revault_tx::Error),
 }
 
@@ -34,6 +36,10 @@ impl std::fmt::Display for BitcoindError {
         match self {
             BitcoindError::Custom(ref s) => write!(f, "Bitcoind manager error: {}", s),
             BitcoindError::Server(ref e) => write!(f, "Bitcoind server error: {}", e),
+            BitcoindError::BatchMissingResponse => write!(
+                f,
+                "Bitcoind server replied without enough responses to our batched request"
+            ),
             BitcoindError::RevaultTx(ref s) => write!(f, "Bitcoind manager error: {}", s),
         }
     }

--- a/src/daemon/control.rs
+++ b/src/daemon/control.rs
@@ -327,7 +327,9 @@ pub fn presigned_txs_list_from_outpoints(
         let mut emergency = None;
         let mut unvault_emergency = None;
         if revaultd.is_stakeholder() {
-            let (_, emer_psbt) = db_emer_transaction(db_path, db_vault.id)?;
+            // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
+            let (_, emer_psbt) = db_emer_transaction(db_path, db_vault.id)?
+                .expect("Must be here post 'Funded' state");
             let mut finalized_emer = emer_psbt.clone();
             emergency = Some(VaultPresignedTransaction {
                 transaction: if finalized_emer.finalize(&revaultd.secp_ctx).is_ok() {
@@ -338,7 +340,9 @@ pub fn presigned_txs_list_from_outpoints(
                 psbt: emer_psbt,
             });
 
-            let (_, unemer_psbt) = db_unvault_emer_transaction(db_path, db_vault.id)?;
+            // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
+            let (_, unemer_psbt) = db_unvault_emer_transaction(db_path, db_vault.id)?
+                .expect("Must be here post 'Funded' state");
             let mut finalized_unemer = unemer_psbt.clone();
             unvault_emergency = Some(VaultPresignedTransaction {
                 transaction: if finalized_unemer.finalize(&revaultd.secp_ctx).is_ok() {
@@ -415,11 +419,17 @@ pub fn onchain_txs_list_from_outpoints(
                 let mut emergency = None;
                 let mut unvault_emergency = None;
                 if revaultd.is_stakeholder() {
-                    let emer = db_emer_transaction(db_path, db_vault.id)?.1;
+                    // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
+                    let emer = db_emer_transaction(db_path, db_vault.id)?
+                        .expect("Must be here post 'Funded' state")
+                        .1;
                     emergency =
                         bitcoind_wallet_tx(bitcoind_tx, emer.into_psbt().extract_tx().txid())?;
 
-                    let unemer = db_unvault_emer_transaction(db_path, db_vault.id)?.1;
+                    // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
+                    let unemer = db_unvault_emer_transaction(db_path, db_vault.id)?
+                        .expect("Must be here if not 'unconfirmed'")
+                        .1;
                     unvault_emergency =
                         bitcoind_wallet_tx(bitcoind_tx, unemer.into_psbt().extract_tx().txid())?;
                 }

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -423,6 +423,22 @@ pub fn db_unconfirm_cancel_dbtx(
     dbtx_downgrade(db_tx, vault_id, VaultStatus::Canceling)
 }
 
+/// Downgrade a vault from 'emergencied' to 'emergencying'
+pub fn db_unconfirm_emer_dbtx(
+    db_tx: &rusqlite::Transaction,
+    vault_id: u32,
+) -> Result<(), DatabaseError> {
+    dbtx_downgrade(db_tx, vault_id, VaultStatus::EmergencyVaulting)
+}
+
+/// Downgrade a vault from 'unvaultemergencied' to 'unvaultemergencying'
+pub fn db_unconfirm_unemer_dbtx(
+    db_tx: &rusqlite::Transaction,
+    vault_id: u32,
+) -> Result<(), DatabaseError> {
+    dbtx_downgrade(db_tx, vault_id, VaultStatus::UnvaultEmergencyVaulting)
+}
+
 fn db_status_from_unvault_txid(
     db_path: &PathBuf,
     unvault_txid: &Txid,
@@ -450,6 +466,7 @@ pub fn db_confirm_unvault(db_path: &PathBuf, unvault_txid: &Txid) -> Result<(), 
     db_status_from_unvault_txid(db_path, unvault_txid, VaultStatus::Unvaulted)
 }
 
+/// Mark a vault as being in the 'canceling' state, out of the Unvault txid
 pub fn db_cancel_unvault(db_path: &PathBuf, unvault_txid: &Txid) -> Result<(), DatabaseError> {
     db_status_from_unvault_txid(db_path, unvault_txid, VaultStatus::Canceling)
 }
@@ -472,6 +489,11 @@ pub fn db_spend_unvault(
     })
 }
 
+/// Mark a vault as being in the 'unvault_emergency_vaulting' state, out of the Unvault txid
+pub fn db_emer_unvault(db_path: &PathBuf, unvault_txid: &Txid) -> Result<(), DatabaseError> {
+    db_status_from_unvault_txid(db_path, unvault_txid, VaultStatus::UnvaultEmergencyVaulting)
+}
+
 fn db_mark_vault_as(
     db_path: &PathBuf,
     vault_id: u32,
@@ -488,12 +510,25 @@ fn db_mark_vault_as(
         Ok(())
     })
 }
+
 pub fn db_mark_spent_unvault(db_path: &PathBuf, vault_id: u32) -> Result<(), DatabaseError> {
     db_mark_vault_as(&db_path, vault_id, VaultStatus::Spent)
 }
 
 pub fn db_mark_canceled_unvault(db_path: &PathBuf, vault_id: u32) -> Result<(), DatabaseError> {
     db_mark_vault_as(&db_path, vault_id, VaultStatus::Canceled)
+}
+
+pub fn db_mark_emergencied_unvault(db_path: &PathBuf, vault_id: u32) -> Result<(), DatabaseError> {
+    db_mark_vault_as(&db_path, vault_id, VaultStatus::UnvaultEmergencyVaulted)
+}
+
+pub fn db_mark_emergencying_vault(db_path: &PathBuf, vault_id: u32) -> Result<(), DatabaseError> {
+    db_mark_vault_as(&db_path, vault_id, VaultStatus::EmergencyVaulting)
+}
+
+pub fn db_mark_emergencied_vault(db_path: &PathBuf, vault_id: u32) -> Result<(), DatabaseError> {
+    db_mark_vault_as(&db_path, vault_id, VaultStatus::EmergencyVaulted)
 }
 
 /// Mark that we actually signed this vault's revocation txs, and stored the signatures for it.

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -1000,7 +1000,8 @@ mod test {
             .unwrap();
         assert_eq!(stored_cancel_tx.inner_tx().inputs[0].partial_sigs.len(), 1);
 
-        let (tx_db_id, stored_emer_tx) = db_emer_transaction(&db_path, db_vault.id).unwrap();
+        let (tx_db_id, stored_emer_tx) =
+            db_emer_transaction(&db_path, db_vault.id).unwrap().unwrap();
         assert_eq!(stored_emer_tx.inner_tx().inputs[0].partial_sigs.len(), 0);
         let mut emer_tx = fresh_emer_tx.clone();
         revault_tx_add_dummy_sig(&mut emer_tx, 0);
@@ -1012,11 +1013,12 @@ mod test {
             &revaultd.secp_ctx,
         )
         .unwrap();
-        let (_, stored_emer_tx) = db_emer_transaction(&db_path, db_vault.id).unwrap();
+        let (_, stored_emer_tx) = db_emer_transaction(&db_path, db_vault.id).unwrap().unwrap();
         assert_eq!(stored_emer_tx.inner_tx().inputs[0].partial_sigs.len(), 1);
 
-        let (tx_db_id, stored_unemer_tx) =
-            db_unvault_emer_transaction(&db_path, db_vault.id).unwrap();
+        let (tx_db_id, stored_unemer_tx) = db_unvault_emer_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(stored_unemer_tx.inner_tx().inputs[0].partial_sigs.len(), 0);
         let mut unemer_tx = fresh_unemer_tx.clone();
         revault_tx_add_dummy_sig(&mut unemer_tx, 0);
@@ -1028,7 +1030,9 @@ mod test {
             &revaultd.secp_ctx,
         )
         .unwrap();
-        let (_, stored_unemer_tx) = db_unvault_emer_transaction(&db_path, db_vault.id).unwrap();
+        let (_, stored_unemer_tx) = db_unvault_emer_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(stored_unemer_tx.inner_tx().inputs[0].partial_sigs.len(), 1);
 
         let (tx_db_id, stored_unvault_tx) = db_unvault_transaction(&db_path, db_vault.id).unwrap();
@@ -1049,7 +1053,10 @@ mod test {
         // They can also be queried
         assert_eq!(
             emer_tx,
-            db_emer_transaction(&db_path, db_vault.id).unwrap().1
+            db_emer_transaction(&db_path, db_vault.id)
+                .unwrap()
+                .unwrap()
+                .1
         );
         assert_eq!(
             cancel_tx,
@@ -1061,6 +1068,7 @@ mod test {
         assert_eq!(
             unemer_tx,
             db_unvault_emer_transaction(&db_path, db_vault.id)
+                .unwrap()
                 .unwrap()
                 .1
         );
@@ -1075,11 +1083,15 @@ mod test {
             Ok(())
         })
         .unwrap();
-        db_emer_transaction(&db_path, db_vault.id).unwrap_err();
+        assert!(db_emer_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .is_none());
         assert!(db_cancel_transaction(&db_path, db_vault.id)
             .unwrap()
             .is_none());
-        db_unvault_emer_transaction(&db_path, db_vault.id).unwrap_err();
+        assert!(db_unvault_emer_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .is_none());
         db_unvault_transaction(&db_path, db_vault.id).unwrap_err();
 
         // And re-added of course

--- a/src/daemon/jsonrpc/api.rs
+++ b/src/daemon/jsonrpc/api.rs
@@ -1149,7 +1149,7 @@ impl RpcApi for RpcImpl {
             &spent_vaults,
         )
         .map_err(|e| {
-            JsonRpcError::invalid_params(format!("Broadcasting Unvault transaction(s): '{}'", e))
+            internal_error!(format!("Broadcasting Unvault transaction(s): '{}'", e))
         })?;
         db_mark_broadcastable_spend(&db_path, &spend_txid).map_err(|e| internal_error!(e))?;
 
@@ -1184,7 +1184,7 @@ impl RpcApi for RpcImpl {
             vault,
         )
         .map_err(|e| {
-            JsonRpcError::invalid_params(format!("Broadcasting Cancel transaction: '{}'", e))
+            internal_error!(format!("Broadcasting Cancel transaction: '{}'", e))
         })?;
 
         Ok(json!({}))

--- a/src/daemon/jsonrpc/api.rs
+++ b/src/daemon/jsonrpc/api.rs
@@ -482,8 +482,10 @@ impl RpcApi for RpcImpl {
                 db_txid, rpc_txid
             )));
         }
+        // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
         let (emer_db_id, db_emergency_tx) = db_emer_transaction(&revaultd.db_file(), db_vault.id)
-            .map_err(|e| internal_error!(e))?;
+            .map_err(|e| internal_error!(e))?
+            .expect("Must be here if 'funded'");
         let rpc_txid = emergency_tx.inner_tx().global.unsigned_tx.wtxid();
         let db_txid = db_emergency_tx.inner_tx().global.unsigned_tx.wtxid();
         if rpc_txid != db_txid {
@@ -492,9 +494,11 @@ impl RpcApi for RpcImpl {
                 db_txid, rpc_txid
             )));
         }
+        // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
         let (unvault_emer_db_id, db_unemergency_tx) =
             db_unvault_emer_transaction(&revaultd.db_file(), db_vault.id)
-                .map_err(|e| internal_error!(e))?;
+                .map_err(|e| internal_error!(e))?
+                .expect("Must be here if 'funded'");
         let rpc_txid = unvault_emergency_tx.inner_tx().global.unsigned_tx.wtxid();
         let db_txid = db_unemergency_tx.inner_tx().global.unsigned_tx.wtxid();
         if rpc_txid != db_txid {

--- a/src/daemon/threadmessages.rs
+++ b/src/daemon/threadmessages.rs
@@ -9,7 +9,10 @@ pub enum BitcoindMessageOut {
     Shutdown,
     SyncProgress(SyncSender<f64>),
     WalletTransaction(Txid, SyncSender<Option<WalletTransaction>>),
-    BroadcastTransaction(BitcoinTransaction, SyncSender<Result<(), BitcoindError>>),
+    BroadcastTransactions(
+        Vec<BitcoinTransaction>,
+        SyncSender<Result<(), BitcoindError>>,
+    ),
 }
 
 /// Outgoing to the signature fetcher thread

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -119,7 +119,7 @@ def bitcoind(directory):
     bitcoind = BitcoinD(bitcoin_dir=directory)
     bitcoind.startup()
 
-    bitcoind.rpc.createwallet(bitcoind.rpc.wallet_name, False, False, "", True)
+    bitcoind.rpc.createwallet(bitcoind.rpc.wallet_name, False, False, "", False, True)
 
     while bitcoind.rpc.getbalance() < 50:
         bitcoind.rpc.generatetoaddress(1, bitcoind.rpc.getnewaddress())
@@ -151,6 +151,8 @@ def revaultd_stakeholder(bitcoind, directory):
     stk_config = {
         "keychain": stks[0],
         "watchtowers": [{"host": "127.0.0.1:1", "noise_key": os.urandom(32)}],
+        # We use a dummy one since we don't use it anyways
+        "emergency_address": "bcrt1qewc2348370pgw8kjz8gy09z8xyh0d9fxde6nzamd3txc9gkmjqmq8m4cdq",
     }
     coordinator_noise_key = (
         "d91563973102454a7830137e92d0548bc83b4ea2799f1df04622ca1307381402"
@@ -192,6 +194,8 @@ def revaultd_manager(bitcoind, directory):
     man_config = {
         "keychain": mans[0],
         "cosigners": [{"host": "127.0.0.1:1", "noise_key": os.urandom(32)}],
+        # We use a dummy one since we don't use it anyways
+        "emergency_address": "bcrt1qewc2348370pgw8kjz8gy09z8xyh0d9fxde6nzamd3txc9gkmjqmq8m4cdq",
     }
     coordinator_noise_key = (
         "d91563973102454a7830137e92d0548bc83b4ea2799f1df04622ca1307381402"

--- a/tests/test_framework/revaultd.py
+++ b/tests/test_framework/revaultd.py
@@ -78,11 +78,7 @@ class Revaultd(TailableProc):
                         f"\"{wt['noise_key'].hex()}\" }}, "
                     )
                 f.write("]\n")
-                # FIXME: eventually use a real one here
-                f.write(
-                    "emergency_address = "
-                    '"bcrt1qewc2348370pgw8kjz8gy09z8xyh0d9fxde6nzamd3txc9gkmjqmq8m4cdq"\n'
-                )
+                f.write(f"emergency_address = \"{stk_config['emergency_address']}\"\n")
 
             if man_config is not None:
                 f.write("[manager_config]\n")


### PR DESCRIPTION
This implements an RPC command for triggering the Emergency process (panic broadcast of all Emergency transactions), as well as the state tracking for both first and second stage Emergency transactions (deposit and unvault).

This does not take care of every edge case nor makes a big deal of the state tracking on the manager side (remember, they don't have the Emergency address and therefore can't recognize it, though they could guess with some heuristics). That's because i think we should eventually have a bulk hardening in case of either the user triggering Emergency, or us noticing an ongoing Emergency.

Also, the `bitcoind` module becomes quite bloated, ugly and hard to follow: i had to stop to refactor it. A followup cleanup PR is ongoing.

Based on #210 .
Fixes #127 .