### PR TITLE
refactoring: bitcoind module cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ the coins stored and may or may not own them) logic is part of this daemon.
 
 Please see [`doc/DEMO.md`](doc/DEMO.md) if you want a tutorial on how to do a deployment
 in regtest on Linux of revaultd.
-You can find more RPC commands at [`doc/API.md`](doc/API.md) but all aren't implemented
-yet!
+
+You can find a reference of available RPC commands at [`doc/API.md`](doc/API.md).
 
 See also the [functional tests](tests/) for a more complete integration (especially with
-the coordinator).
+the Coordinator and Cosigning Servers).
 
 # Contributing
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -21,6 +21,7 @@ Note that all addresses are bech32-encoded *version 0* native Segwit `scriptPubK
 | [`setspendtx`](#setspendtx)                                 | Announce and broadcast this Spend transaction        |
 | [`listspendtxs`](#listspendtxs)                             | List all stored Spend transactions                   |
 | [`gethistory`](#gethistory)                                 | Retrieve history of funds                            |
+| [`emergency`](#emergency)                                   | Broadcast all Emergency signed transactions          |
 
 
 
@@ -410,6 +411,20 @@ of inflows and outflows net of any change amount (that is technically a transact
 | `date`   | int    | Timestamp of the event                                                                   |
 | `amount` | int    | Absolute amount in satoshis that is entering or exiting the wallet                       |
 | `fee`    | int    | Fee of the event transaction                                                             |
+
+
+### `emergency`
+
+#### Request
+
+| Field          | Type   | Description                                    |
+| -------------- | ------ | ---------------------------------------------- |
+
+#### Response
+
+None; the `result` field will be set to the empty object `{}`. Any value should be
+disregarded for forward compatibility.
+
 
 ## User flows
 

--- a/src/daemon/bitcoind/actions.rs
+++ b/src/daemon/bitcoind/actions.rs
@@ -1696,13 +1696,13 @@ pub fn bitcoind_main_loop(
                         ))
                     })?;
             }
-            BitcoindMessageOut::BroadcastTransaction(tx, resp_tx) => {
-                log::trace!("Received 'broadcastransaction' from main thread");
+            BitcoindMessageOut::BroadcastTransactions(txs, resp_tx) => {
+                log::trace!("Received 'broadcastransactions' from main thread");
                 resp_tx
-                    .send(bitcoind.read().unwrap().broadcast_transaction(&tx))
+                    .send(bitcoind.read().unwrap().broadcast_transactions(&txs))
                     .map_err(|e| {
                         BitcoindError::Custom(format!(
-                            "Sending wallet transaction to main thread: {}",
+                            "Sending transactions broadcast result to main thread: {}",
                             e
                         ))
                     })?;

--- a/src/daemon/bitcoind/interface.rs
+++ b/src/daemon/bitcoind/interface.rs
@@ -704,6 +704,15 @@ impl BitcoinD {
             .map(|_| ())
     }
 
+    /// Broadcast a batch of transactions with 'sendrawtransaction'
+    pub fn broadcast_transactions(&self, txs: &[Transaction]) -> Result<(), BitcoindError> {
+        for tx in txs {
+            self.broadcast_transaction(&tx)?;
+        }
+
+        Ok(())
+    }
+
     /// Broadcast a transaction that is already part of the wallet
     pub fn rebroadcast_wallet_tx(&self, txid: &Txid) -> Result<(), BitcoindError> {
         let (hex, _, _) = self.get_wallet_transaction(txid)?;

--- a/src/daemon/bitcoind/mod.rs
+++ b/src/daemon/bitcoind/mod.rs
@@ -208,6 +208,7 @@ pub fn bitcoind_main_loop(
             }
             BitcoindMessageOut::WalletTransaction(txid, resp_tx) => {
                 log::trace!("Received 'wallettransaction' from main thread");
+                // FIXME: what if bitcoind isn't synced?
                 resp_tx
                     .send(wallet_transaction(&bitcoind.read().unwrap(), txid))
                     .map_err(|e| {

--- a/src/daemon/bitcoind/mod.rs
+++ b/src/daemon/bitcoind/mod.rs
@@ -1,5 +1,6 @@
 pub mod interface;
 pub mod poller;
+pub mod utils;
 
 use crate::{
     database::DatabaseError,

--- a/src/daemon/bitcoind/mod.rs
+++ b/src/daemon/bitcoind/mod.rs
@@ -15,6 +15,8 @@ pub enum BitcoindError {
     Custom(String),
     /// Or directly to bitcoind's RPC server
     Server(Error),
+    /// They replied to a batch request omitting some responses
+    BatchMissingResponse,
     RevaultTx(revault_tx::Error),
 }
 
@@ -34,6 +36,10 @@ impl std::fmt::Display for BitcoindError {
         match self {
             BitcoindError::Custom(ref s) => write!(f, "Bitcoind manager error: {}", s),
             BitcoindError::Server(ref e) => write!(f, "Bitcoind server error: {}", e),
+            BitcoindError::BatchMissingResponse => write!(
+                f,
+                "Bitcoind server replied without enough responses to our batched request"
+            ),
             BitcoindError::RevaultTx(ref s) => write!(f, "Bitcoind manager error: {}", s),
         }
     }

--- a/src/daemon/bitcoind/mod.rs
+++ b/src/daemon/bitcoind/mod.rs
@@ -1,12 +1,31 @@
-use crate::database::DatabaseError;
+pub mod interface;
+pub mod poller;
+
+use crate::{
+    database::DatabaseError,
+    revaultd::RevaultD,
+    threadmessages::{BitcoindMessageOut, WalletTransaction},
+};
+use common::{assume_ok, config::BitcoindConfig};
+use interface::BitcoinD;
+use poller::poller_main;
+use revault_tx::bitcoin::{Network, Txid};
+
+use std::{
+    process,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::Receiver,
+        Arc, RwLock,
+    },
+    thread,
+    time::Duration,
+};
 
 use jsonrpc::{
     error::{Error, RpcError},
     simple_http,
 };
-
-pub mod actions;
-pub mod interface;
 
 /// An error happened in the bitcoind-manager thread
 #[derive(Debug)]
@@ -63,4 +82,154 @@ impl From<revault_tx::Error> for BitcoindError {
     fn from(e: revault_tx::Error) -> Self {
         Self::RevaultTx(e)
     }
+}
+
+fn check_bitcoind_network(
+    bitcoind: &BitcoinD,
+    config_network: &Network,
+) -> Result<(), BitcoindError> {
+    let chaininfo = bitcoind.getblockchaininfo()?;
+    let chain = chaininfo
+        .get("chain")
+        .and_then(|c| c.as_str())
+        .ok_or_else(|| {
+            BitcoindError::Custom("No valid 'chain' in getblockchaininfo response?".to_owned())
+        })?;
+    let bip70_net = match config_network {
+        Network::Bitcoin => "main",
+        Network::Testnet => "test",
+        Network::Regtest => "regtest",
+        Network::Signet => "signet",
+    };
+
+    if !bip70_net.eq(chain) {
+        return Err(BitcoindError::Custom(format!(
+            "Wrong network, bitcoind is on '{}' but our config says '{}' ({})",
+            chain, bip70_net, config_network
+        )));
+    }
+
+    Ok(())
+}
+
+/// Some sanity checks to be done at startup to make sure our bitcoind isn't going to fail under
+/// our feet for a legitimate reason.
+fn bitcoind_sanity_checks(
+    bitcoind: &BitcoinD,
+    bitcoind_config: &BitcoindConfig,
+) -> Result<(), BitcoindError> {
+    check_bitcoind_network(&bitcoind, &bitcoind_config.network)
+}
+
+/// Connects to and sanity checks bitcoind.
+pub fn start_bitcoind(revaultd: &mut RevaultD) -> Result<BitcoinD, BitcoindError> {
+    let bitcoind = BitcoinD::new(
+        &revaultd.bitcoind_config,
+        revaultd
+            .watchonly_wallet_file()
+            .expect("Wallet id is set at startup in setup_db()"),
+    )
+    .map_err(|e| {
+        BitcoindError::Custom(format!("Could not connect to bitcoind: {}", e.to_string()))
+    })?;
+
+    while let Err(e) = bitcoind_sanity_checks(&bitcoind, &revaultd.bitcoind_config) {
+        if e.is_warming_up() {
+            log::info!("Bitcoind is warming up. Waiting for it to be back up.");
+            thread::sleep(Duration::from_secs(3))
+        } else {
+            return Err(e);
+        }
+    }
+
+    Ok(bitcoind)
+}
+
+fn wallet_transaction(bitcoind: &BitcoinD, txid: Txid) -> Option<WalletTransaction> {
+    let res = bitcoind.get_wallet_transaction(&txid);
+    if let Ok((hex, blockheight, received_time)) = res {
+        Some(WalletTransaction {
+            hex,
+            blockheight,
+            received_time,
+        })
+    } else {
+        log::trace!(
+            "Got '{:?}' from bitcoind when requesting wallet transaction '{}'",
+            res,
+            txid
+        );
+        None
+    }
+}
+
+/// The bitcoind event loop.
+/// Listens for bitcoind requests (wallet / chain) and poll bitcoind every 30 seconds,
+/// updating our state accordingly.
+pub fn bitcoind_main_loop(
+    rx: Receiver<BitcoindMessageOut>,
+    revaultd: Arc<RwLock<RevaultD>>,
+    bitcoind: Arc<RwLock<BitcoinD>>,
+) -> Result<(), BitcoindError> {
+    // The verification progress announced by bitcoind *at startup* thus won't be updated
+    // after startup check. Should be *exactly* 1.0 when synced, but hey, floats so we are
+    // careful.
+    let sync_progress = Arc::new(RwLock::new(0.0f64));
+    // Used to shutdown the poller thread
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    // We use a thread to 1) wait for bitcoind to be synced 2) poll listunspent
+    let poller_thread = std::thread::spawn({
+        let _revaultd = revaultd.clone();
+        let _bitcoind = bitcoind.clone();
+        let _sync_progress = sync_progress.clone();
+        let _shutdown = shutdown.clone();
+        move || poller_main(_revaultd, _bitcoind, _sync_progress, _shutdown)
+    });
+
+    for msg in rx {
+        match msg {
+            BitcoindMessageOut::Shutdown => {
+                log::info!("Bitcoind received shutdown from main. Exiting.");
+                shutdown.store(true, Ordering::Relaxed);
+                assume_ok!(
+                    assume_ok!(poller_thread.join(), "Joining bitcoind poller thread"),
+                    "Error in bitcoind poller thread"
+                );
+                return Ok(());
+            }
+            BitcoindMessageOut::SyncProgress(resp_tx) => {
+                resp_tx.send(*sync_progress.read().unwrap()).map_err(|e| {
+                    BitcoindError::Custom(format!(
+                        "Sending synchronization progress to main thread: {}",
+                        e
+                    ))
+                })?;
+            }
+            BitcoindMessageOut::WalletTransaction(txid, resp_tx) => {
+                log::trace!("Received 'wallettransaction' from main thread");
+                resp_tx
+                    .send(wallet_transaction(&bitcoind.read().unwrap(), txid))
+                    .map_err(|e| {
+                        BitcoindError::Custom(format!(
+                            "Sending wallet transaction to main thread: {}",
+                            e
+                        ))
+                    })?;
+            }
+            BitcoindMessageOut::BroadcastTransactions(txs, resp_tx) => {
+                log::trace!("Received 'broadcastransactions' from main thread");
+                resp_tx
+                    .send(bitcoind.read().unwrap().broadcast_transactions(&txs))
+                    .map_err(|e| {
+                        BitcoindError::Custom(format!(
+                            "Sending transactions broadcast result to main thread: {}",
+                            e
+                        ))
+                    })?;
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/src/daemon/bitcoind/poller.rs
+++ b/src/daemon/bitcoind/poller.rs
@@ -37,7 +37,7 @@ use revault_tx::{
 
 use std::{
     collections::HashMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, RwLock,
@@ -85,7 +85,7 @@ fn maybe_broadcast_spend_transactions(
 }
 
 fn maybe_confirm_spend(
-    db_path: &PathBuf,
+    db_path: &Path,
     bitcoind: &BitcoinD,
     db_vault: &DbVault,
     spend_txid: &Txid,
@@ -172,7 +172,7 @@ fn mark_confirmed_spends(
 // Unvault is dropped from the mempool. This groups the code for doing so.
 fn mark_unvaulted(
     revaultd: &Arc<RwLock<RevaultD>>,
-    db_path: &PathBuf,
+    db_path: &Path,
     unvaults_cache: &mut HashMap<OutPoint, UtxoInfo>,
     db_vault: &DbVault,
 ) -> Result<(), BitcoindError> {
@@ -206,7 +206,7 @@ fn mark_unvaulted(
 }
 
 fn maybe_confirm_cancel(
-    db_path: &PathBuf,
+    db_path: &Path,
     bitcoind: &BitcoinD,
     db_vault: &DbVault,
     cancel_txid: &Txid,
@@ -262,7 +262,7 @@ fn mark_confirmed_cancels(
 }
 
 fn maybe_confirm_unemer(
-    db_path: &PathBuf,
+    db_path: &Path,
     bitcoind: &BitcoinD,
     db_vault: &DbVault,
     unemer_txid: &Txid,
@@ -324,7 +324,7 @@ fn mark_confirmed_unemers(
 }
 
 fn maybe_confirm_emer(
-    db_path: &PathBuf,
+    db_path: &Path,
     bitcoind: &BitcoinD,
     db_vault: &DbVault,
     emer_txid: &Txid,
@@ -932,7 +932,7 @@ fn unvault_spender(
 // Update the state of a vault whose Unvault txo was spent.
 fn handle_spent_unvault(
     revaultd: &mut Arc<RwLock<RevaultD>>,
-    db_path: &PathBuf,
+    db_path: &Path,
     bitcoind: &BitcoinD,
     unvaults_cache: &mut HashMap<OutPoint, UtxoInfo>,
     previous_tip: &BlockchainTip,
@@ -1035,7 +1035,7 @@ fn handle_spent_unvault(
 // Update our state when a new UTXO appears that is paying to the Deposit descriptor
 fn handle_new_deposit(
     revaultd: &mut Arc<RwLock<RevaultD>>,
-    db_path: &PathBuf,
+    db_path: &Path,
     bitcoind: &BitcoinD,
     deposits_cache: &mut HashMap<OutPoint, UtxoInfo>,
     outpoint: OutPoint,
@@ -1118,7 +1118,7 @@ fn handle_new_deposit(
 // Update our state when we notice a deeply-enough confirmed deposit UTXO
 fn handle_confirmed_deposit(
     revaultd: &mut Arc<RwLock<RevaultD>>,
-    db_path: &PathBuf,
+    db_path: &Path,
     bitcoind: &BitcoinD,
     deposits_cache: &mut HashMap<OutPoint, UtxoInfo>,
     outpoint: OutPoint,
@@ -1177,7 +1177,7 @@ fn handle_confirmed_deposit(
 // to figure out where it went.
 fn handle_spent_deposit(
     revaultd: &mut Arc<RwLock<RevaultD>>,
-    db_path: &PathBuf,
+    db_path: &Path,
     bitcoind: &BitcoinD,
     deposits_cache: &mut HashMap<OutPoint, UtxoInfo>,
     unvaults_cache: &mut HashMap<OutPoint, UtxoInfo>,

--- a/src/daemon/bitcoind/poller.rs
+++ b/src/daemon/bitcoind/poller.rs
@@ -1,6 +1,10 @@
 use crate::{
     bitcoind::{
         interface::{BitcoinD, OnchainDescriptorState, SyncInfo, UtxoInfo},
+        utils::{
+            cancel_txid, emer_txid, populate_deposit_cache, populate_unvaults_cache,
+            presigned_transactions, unemer_txid, unvault_txin_from_deposit,
+        },
         BitcoindError,
     },
     database::{
@@ -14,12 +18,10 @@ use crate::{
             db_unvault_deposit, db_update_deposit_index, db_update_tip, db_update_tip_dbtx,
         },
         interface::{
-            db_broadcastable_spend_transactions, db_cancel_dbtx, db_cancel_transaction,
-            db_canceling_vaults, db_deposits, db_emer_transaction, db_emering_vaults, db_exec,
-            db_spending_vaults, db_tip, db_unemering_vaults, db_unvault_dbtx,
-            db_unvault_emer_transaction, db_unvault_from_deposit, db_unvault_transaction,
-            db_unvaulted_vaults, db_vault_by_deposit, db_vault_by_unvault_txid, db_vaults_dbtx,
-            db_wallet,
+            db_broadcastable_spend_transactions, db_cancel_dbtx, db_canceling_vaults,
+            db_emering_vaults, db_exec, db_spending_vaults, db_tip, db_unemering_vaults,
+            db_unvault_dbtx, db_unvault_transaction, db_vault_by_deposit, db_vault_by_unvault_txid,
+            db_vaults_dbtx, db_wallet,
         },
         schema::DbVault,
     },
@@ -27,14 +29,10 @@ use crate::{
 };
 use common::config::BitcoindConfig;
 use revault_tx::{
-    bitcoin::{Amount, OutPoint, TxOut, Txid},
-    miniscript::DescriptorTrait,
-    transactions::{
-        transaction_chain, transaction_chain_manager, CancelTransaction, EmergencyTransaction,
-        RevaultTransaction, UnvaultEmergencyTransaction, UnvaultTransaction,
-    },
-    txins::{DepositTxIn, RevaultTxIn, UnvaultTxIn},
-    txouts::{DepositTxOut, RevaultTxOut},
+    bitcoin::{Amount, OutPoint, Txid},
+    transactions::{RevaultTransaction, UnvaultTransaction},
+    txins::RevaultTxIn,
+    txouts::RevaultTxOut,
 };
 
 use std::{
@@ -876,253 +874,6 @@ fn update_tip(
     log::info!("Rescan of all vaults in db done.");
 
     Ok(current_tip)
-}
-
-// Get fresh to-be-presigned transactions for this deposit utxo
-fn presigned_transactions(
-    revaultd: &RevaultD,
-    outpoint: OutPoint,
-    utxo: UtxoInfo,
-) -> Result<
-    (
-        UnvaultTransaction,
-        CancelTransaction,
-        Option<EmergencyTransaction>,
-        Option<UnvaultEmergencyTransaction>,
-    ),
-    BitcoindError,
-> {
-    // We use the same derivation index for all descriptors.
-    let derivation_index = *revaultd
-        .derivation_index_map
-        .get(&utxo.txo.script_pubkey)
-        .ok_or_else(|| {
-            BitcoindError::Custom(format!("Unknown derivation index for: {:#?}", &utxo))
-        })?;
-
-    // Reconstruct the deposit UTXO and derive all pre-signed transactions out of it
-    // if we are a stakeholder, and only the Unvault and the Cancel if we are a manager.
-    if revaultd.is_stakeholder() {
-        let emer_address = revaultd
-            .emergency_address
-            .clone()
-            .expect("We are a stakeholder");
-        let (unvault_tx, cancel_tx, emer_tx, unemer_tx) = transaction_chain(
-            outpoint,
-            Amount::from_sat(utxo.txo.value),
-            &revaultd.deposit_descriptor,
-            &revaultd.unvault_descriptor,
-            &revaultd.cpfp_descriptor,
-            derivation_index,
-            emer_address,
-            revaultd.lock_time,
-            &revaultd.secp_ctx,
-        )?;
-        Ok((unvault_tx, cancel_tx, Some(emer_tx), Some(unemer_tx)))
-    } else {
-        let (unvault_tx, cancel_tx) = transaction_chain_manager(
-            outpoint,
-            Amount::from_sat(utxo.txo.value),
-            &revaultd.deposit_descriptor,
-            &revaultd.unvault_descriptor,
-            &revaultd.cpfp_descriptor,
-            derivation_index,
-            revaultd.lock_time,
-            &revaultd.secp_ctx,
-        )?;
-        Ok((unvault_tx, cancel_tx, None, None))
-    }
-}
-
-// Fill up the deposit UTXOs cache from db vaults
-fn populate_deposit_cache(
-    revaultd: &RevaultD,
-) -> Result<HashMap<OutPoint, UtxoInfo>, BitcoindError> {
-    let db_vaults = db_deposits(&revaultd.db_file())?;
-    let mut cache = HashMap::with_capacity(db_vaults.len());
-
-    for db_vault in db_vaults.into_iter() {
-        let der_deposit_descriptor = revaultd
-            .deposit_descriptor
-            .derive(db_vault.derivation_index, &revaultd.secp_ctx);
-        let script_pubkey = der_deposit_descriptor.inner().script_pubkey();
-        let txo = TxOut {
-            script_pubkey,
-            value: db_vault.amount.as_sat(),
-        };
-        cache.insert(
-            db_vault.deposit_outpoint,
-            UtxoInfo {
-                txo,
-                is_confirmed: !matches!(db_vault.status, VaultStatus::Unconfirmed),
-            },
-        );
-        log::debug!("Loaded deposit '{}' from db", db_vault.deposit_outpoint);
-    }
-
-    Ok(cache)
-}
-
-// Fill up the unvault UTXOs cache from db vaults
-fn populate_unvaults_cache(
-    revaultd: &RevaultD,
-) -> Result<HashMap<OutPoint, UtxoInfo>, BitcoindError> {
-    let db_unvaults = db_unvaulted_vaults(&revaultd.db_file())?;
-    let mut cache = HashMap::with_capacity(db_unvaults.len());
-
-    for (db_vault, unvault_tx) in db_unvaults.into_iter() {
-        let unvault_descriptor = revaultd.derived_unvault_descriptor(db_vault.derivation_index);
-        let unvault_txin = unvault_tx.revault_unvault_txin(&unvault_descriptor);
-        let unvault_outpoint = unvault_txin.outpoint();
-        let txo = unvault_txin.into_txout().into_txout();
-        cache.insert(
-            unvault_outpoint,
-            UtxoInfo {
-                txo,
-                is_confirmed: !matches!(db_vault.status, VaultStatus::Unvaulting),
-            },
-        );
-        log::debug!("Loaded Unvault Utxo '{}' from db", unvault_outpoint);
-    }
-
-    Ok(cache)
-}
-
-// Get the Unvault transaction outpoint from a deposit, trying first to fetch the transaction
-// from the DB and falling back to generating it.
-// Assumes the given deposit outpoint actually corresponds to an existing vaults, will panic
-// otherwise.
-fn unvault_txin_from_deposit(
-    revaultd: &Arc<RwLock<RevaultD>>,
-    deposit_outpoint: &OutPoint,
-    deposit_utxo: TxOut,
-) -> Result<UnvaultTxIn, BitcoindError> {
-    let revaultd = revaultd.read().unwrap();
-    let db_path = revaultd.db_file();
-    let db_vault = db_vault_by_deposit(&db_path, &deposit_outpoint)?
-        .expect("Checking Unvault txid for an unknow deposit");
-    let unvault_descriptor = revaultd.derived_unvault_descriptor(db_vault.derivation_index);
-
-    let unvault_tx = if let Some(tx) = db_unvault_from_deposit(&db_path, &deposit_outpoint)? {
-        tx
-    } else {
-        let deposit_descriptor = revaultd.derived_deposit_descriptor(db_vault.derivation_index);
-
-        let deposit_txo = DepositTxOut::new(deposit_utxo.value, &deposit_descriptor);
-        let deposit_txin = DepositTxIn::new(*deposit_outpoint, deposit_txo);
-
-        let cpfp_descriptor = revaultd.derived_cpfp_descriptor(db_vault.derivation_index);
-        UnvaultTransaction::new(
-            deposit_txin,
-            &unvault_descriptor,
-            &cpfp_descriptor,
-            revaultd.lock_time,
-        )
-        .map_err(|e| BitcoindError::Custom(format!("Error deriving Unvault tx: '{}'", e)))?
-    };
-
-    Ok(unvault_tx.revault_unvault_txin(&unvault_descriptor))
-}
-
-// Get the Cancel txid of a give vault, trying first to fetch the transaction from the DB and
-// falling back to generating it.
-// Assumes the given deposit outpoint actually corresponds to an existing vaults, will panic
-// otherwise.
-fn cancel_txid(
-    revaultd: &Arc<RwLock<RevaultD>>,
-    db_vault: &DbVault,
-) -> Result<Txid, BitcoindError> {
-    let revaultd = revaultd.read().unwrap();
-    let db_path = revaultd.db_file();
-
-    let cancel_tx = if let Some((_, db_tx)) = db_cancel_transaction(&db_path, db_vault.id)? {
-        db_tx
-    } else {
-        let (_, cancel_tx) = transaction_chain_manager(
-            db_vault.deposit_outpoint,
-            db_vault.amount,
-            &revaultd.deposit_descriptor,
-            &revaultd.unvault_descriptor,
-            &revaultd.cpfp_descriptor,
-            db_vault.derivation_index,
-            revaultd.lock_time,
-            &revaultd.secp_ctx,
-        )?;
-        cancel_tx
-    };
-
-    Ok(cancel_tx.txid())
-}
-
-// Get the Unvault Emergency transaction id, if we are at all able to (ie if we are a stakeholder).
-fn unemer_txid(
-    revaultd: &Arc<RwLock<RevaultD>>,
-    db_vault: &DbVault,
-) -> Result<Option<Txid>, BitcoindError> {
-    let revaultd = revaultd.read().unwrap();
-    let db_path = revaultd.db_file();
-
-    if revaultd.is_stakeholder() {
-        let unemer_tx =
-            if let Some((_, db_tx)) = db_unvault_emer_transaction(&db_path, db_vault.id)? {
-                db_tx
-            } else {
-                let (_, _, _, unemer_tx) = transaction_chain(
-                    db_vault.deposit_outpoint,
-                    db_vault.amount,
-                    &revaultd.deposit_descriptor,
-                    &revaultd.unvault_descriptor,
-                    &revaultd.cpfp_descriptor,
-                    db_vault.derivation_index,
-                    revaultd
-                        .emergency_address
-                        .clone()
-                        .expect("Just checked we were a stakeholder"),
-                    revaultd.lock_time,
-                    &revaultd.secp_ctx,
-                )?;
-                unemer_tx
-            };
-
-        return Ok(Some(unemer_tx.txid()));
-    }
-
-    Ok(None)
-}
-
-// Get the Emergency transaction id, if we are at all able to (ie if we are a stakeholder).
-fn emer_txid(
-    revaultd: &Arc<RwLock<RevaultD>>,
-    db_vault: &DbVault,
-) -> Result<Option<Txid>, BitcoindError> {
-    let revaultd = revaultd.read().unwrap();
-    let db_path = revaultd.db_file();
-
-    if revaultd.is_stakeholder() {
-        let unemer_tx = if let Some((_, db_tx)) = db_emer_transaction(&db_path, db_vault.id)? {
-            db_tx
-        } else {
-            let (_, _, emer_tx, _) = transaction_chain(
-                db_vault.deposit_outpoint,
-                db_vault.amount,
-                &revaultd.deposit_descriptor,
-                &revaultd.unvault_descriptor,
-                &revaultd.cpfp_descriptor,
-                db_vault.derivation_index,
-                revaultd
-                    .emergency_address
-                    .clone()
-                    .expect("Just checked we were a stakeholder"),
-                revaultd.lock_time,
-                &revaultd.secp_ctx,
-            )?;
-            emer_tx
-        };
-
-        return Ok(Some(unemer_tx.txid()));
-    }
-
-    Ok(None)
 }
 
 // Which kind of transaction may spend the Unvault transaction.

--- a/src/daemon/bitcoind/utils.rs
+++ b/src/daemon/bitcoind/utils.rs
@@ -1,0 +1,273 @@
+use crate::{
+    bitcoind::{interface::UtxoInfo, BitcoindError},
+    database::{
+        interface::{
+            db_cancel_transaction, db_deposits, db_emer_transaction, db_unvault_emer_transaction,
+            db_unvault_from_deposit, db_unvaulted_vaults, db_vault_by_deposit,
+        },
+        schema::DbVault,
+    },
+    revaultd::{RevaultD, VaultStatus},
+};
+use revault_tx::{
+    bitcoin::{Amount, OutPoint, TxOut, Txid},
+    miniscript::DescriptorTrait,
+    transactions::{
+        transaction_chain, transaction_chain_manager, CancelTransaction, EmergencyTransaction,
+        RevaultTransaction, UnvaultEmergencyTransaction, UnvaultTransaction,
+    },
+    txins::{DepositTxIn, RevaultTxIn, UnvaultTxIn},
+    txouts::{DepositTxOut, RevaultTxOut},
+};
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+/// Get fresh to-be-presigned transactions for this deposit utxo
+pub fn presigned_transactions(
+    revaultd: &RevaultD,
+    outpoint: OutPoint,
+    utxo: UtxoInfo,
+) -> Result<
+    (
+        UnvaultTransaction,
+        CancelTransaction,
+        Option<EmergencyTransaction>,
+        Option<UnvaultEmergencyTransaction>,
+    ),
+    BitcoindError,
+> {
+    // We use the same derivation index for all descriptors.
+    let derivation_index = *revaultd
+        .derivation_index_map
+        .get(&utxo.txo.script_pubkey)
+        .ok_or_else(|| {
+            BitcoindError::Custom(format!("Unknown derivation index for: {:#?}", &utxo))
+        })?;
+
+    // Reconstruct the deposit UTXO and derive all pre-signed transactions out of it
+    // if we are a stakeholder, and only the Unvault and the Cancel if we are a manager.
+    if revaultd.is_stakeholder() {
+        let emer_address = revaultd
+            .emergency_address
+            .clone()
+            .expect("We are a stakeholder");
+        let (unvault_tx, cancel_tx, emer_tx, unemer_tx) = transaction_chain(
+            outpoint,
+            Amount::from_sat(utxo.txo.value),
+            &revaultd.deposit_descriptor,
+            &revaultd.unvault_descriptor,
+            &revaultd.cpfp_descriptor,
+            derivation_index,
+            emer_address,
+            revaultd.lock_time,
+            &revaultd.secp_ctx,
+        )?;
+        Ok((unvault_tx, cancel_tx, Some(emer_tx), Some(unemer_tx)))
+    } else {
+        let (unvault_tx, cancel_tx) = transaction_chain_manager(
+            outpoint,
+            Amount::from_sat(utxo.txo.value),
+            &revaultd.deposit_descriptor,
+            &revaultd.unvault_descriptor,
+            &revaultd.cpfp_descriptor,
+            derivation_index,
+            revaultd.lock_time,
+            &revaultd.secp_ctx,
+        )?;
+        Ok((unvault_tx, cancel_tx, None, None))
+    }
+}
+
+/// Fill up the deposit UTXOs cache from db vaults
+pub fn populate_deposit_cache(
+    revaultd: &RevaultD,
+) -> Result<HashMap<OutPoint, UtxoInfo>, BitcoindError> {
+    let db_vaults = db_deposits(&revaultd.db_file())?;
+    let mut cache = HashMap::with_capacity(db_vaults.len());
+
+    for db_vault in db_vaults.into_iter() {
+        let der_deposit_descriptor = revaultd
+            .deposit_descriptor
+            .derive(db_vault.derivation_index, &revaultd.secp_ctx);
+        let script_pubkey = der_deposit_descriptor.inner().script_pubkey();
+        let txo = TxOut {
+            script_pubkey,
+            value: db_vault.amount.as_sat(),
+        };
+        cache.insert(
+            db_vault.deposit_outpoint,
+            UtxoInfo {
+                txo,
+                is_confirmed: !matches!(db_vault.status, VaultStatus::Unconfirmed),
+            },
+        );
+        log::debug!("Loaded deposit '{}' from db", db_vault.deposit_outpoint);
+    }
+
+    Ok(cache)
+}
+
+/// Fill up the unvault UTXOs cache from db vaults
+pub fn populate_unvaults_cache(
+    revaultd: &RevaultD,
+) -> Result<HashMap<OutPoint, UtxoInfo>, BitcoindError> {
+    let db_unvaults = db_unvaulted_vaults(&revaultd.db_file())?;
+    let mut cache = HashMap::with_capacity(db_unvaults.len());
+
+    for (db_vault, unvault_tx) in db_unvaults.into_iter() {
+        let unvault_descriptor = revaultd.derived_unvault_descriptor(db_vault.derivation_index);
+        let unvault_txin = unvault_tx.revault_unvault_txin(&unvault_descriptor);
+        let unvault_outpoint = unvault_txin.outpoint();
+        let txo = unvault_txin.into_txout().into_txout();
+        cache.insert(
+            unvault_outpoint,
+            UtxoInfo {
+                txo,
+                is_confirmed: !matches!(db_vault.status, VaultStatus::Unvaulting),
+            },
+        );
+        log::debug!("Loaded Unvault Utxo '{}' from db", unvault_outpoint);
+    }
+
+    Ok(cache)
+}
+
+/// Get the Unvault transaction outpoint from a deposit, trying first to fetch the transaction
+/// from the DB and falling back to generating it.
+/// Assumes the given deposit outpoint actually corresponds to an existing vaults, will panic
+/// otherwise.
+pub fn unvault_txin_from_deposit(
+    revaultd: &Arc<RwLock<RevaultD>>,
+    deposit_outpoint: &OutPoint,
+    deposit_utxo: TxOut,
+) -> Result<UnvaultTxIn, BitcoindError> {
+    let revaultd = revaultd.read().unwrap();
+    let db_path = revaultd.db_file();
+    let db_vault = db_vault_by_deposit(&db_path, &deposit_outpoint)?
+        .expect("Checking Unvault txid for an unknow deposit");
+    let unvault_descriptor = revaultd.derived_unvault_descriptor(db_vault.derivation_index);
+
+    let unvault_tx = if let Some(tx) = db_unvault_from_deposit(&db_path, &deposit_outpoint)? {
+        tx
+    } else {
+        let deposit_descriptor = revaultd.derived_deposit_descriptor(db_vault.derivation_index);
+
+        let deposit_txo = DepositTxOut::new(deposit_utxo.value, &deposit_descriptor);
+        let deposit_txin = DepositTxIn::new(*deposit_outpoint, deposit_txo);
+
+        let cpfp_descriptor = revaultd.derived_cpfp_descriptor(db_vault.derivation_index);
+        UnvaultTransaction::new(
+            deposit_txin,
+            &unvault_descriptor,
+            &cpfp_descriptor,
+            revaultd.lock_time,
+        )
+        .map_err(|e| BitcoindError::Custom(format!("Error deriving Unvault tx: '{}'", e)))?
+    };
+
+    Ok(unvault_tx.revault_unvault_txin(&unvault_descriptor))
+}
+
+/// Get the Cancel txid of a give vault, trying first to fetch the transaction from the DB and
+/// falling back to generating it.
+/// Assumes the given deposit outpoint actually corresponds to an existing vaults, will panic
+/// otherwise.
+pub fn cancel_txid(
+    revaultd: &Arc<RwLock<RevaultD>>,
+    db_vault: &DbVault,
+) -> Result<Txid, BitcoindError> {
+    let revaultd = revaultd.read().unwrap();
+    let db_path = revaultd.db_file();
+
+    let cancel_tx = if let Some((_, db_tx)) = db_cancel_transaction(&db_path, db_vault.id)? {
+        db_tx
+    } else {
+        let (_, cancel_tx) = transaction_chain_manager(
+            db_vault.deposit_outpoint,
+            db_vault.amount,
+            &revaultd.deposit_descriptor,
+            &revaultd.unvault_descriptor,
+            &revaultd.cpfp_descriptor,
+            db_vault.derivation_index,
+            revaultd.lock_time,
+            &revaultd.secp_ctx,
+        )?;
+        cancel_tx
+    };
+
+    Ok(cancel_tx.txid())
+}
+
+/// Get the Unvault Emergency transaction id, if we are at all able to (ie if we are a stakeholder).
+pub fn unemer_txid(
+    revaultd: &Arc<RwLock<RevaultD>>,
+    db_vault: &DbVault,
+) -> Result<Option<Txid>, BitcoindError> {
+    let revaultd = revaultd.read().unwrap();
+    let db_path = revaultd.db_file();
+
+    if revaultd.is_stakeholder() {
+        let unemer_tx =
+            if let Some((_, db_tx)) = db_unvault_emer_transaction(&db_path, db_vault.id)? {
+                db_tx
+            } else {
+                let (_, _, _, unemer_tx) = transaction_chain(
+                    db_vault.deposit_outpoint,
+                    db_vault.amount,
+                    &revaultd.deposit_descriptor,
+                    &revaultd.unvault_descriptor,
+                    &revaultd.cpfp_descriptor,
+                    db_vault.derivation_index,
+                    revaultd
+                        .emergency_address
+                        .clone()
+                        .expect("Just checked we were a stakeholder"),
+                    revaultd.lock_time,
+                    &revaultd.secp_ctx,
+                )?;
+                unemer_tx
+            };
+
+        return Ok(Some(unemer_tx.txid()));
+    }
+
+    Ok(None)
+}
+
+/// Get the Emergency transaction id, if we are at all able to (ie if we are a stakeholder).
+pub fn emer_txid(
+    revaultd: &Arc<RwLock<RevaultD>>,
+    db_vault: &DbVault,
+) -> Result<Option<Txid>, BitcoindError> {
+    let revaultd = revaultd.read().unwrap();
+    let db_path = revaultd.db_file();
+
+    if revaultd.is_stakeholder() {
+        let unemer_tx = if let Some((_, db_tx)) = db_emer_transaction(&db_path, db_vault.id)? {
+            db_tx
+        } else {
+            let (_, _, emer_tx, _) = transaction_chain(
+                db_vault.deposit_outpoint,
+                db_vault.amount,
+                &revaultd.deposit_descriptor,
+                &revaultd.unvault_descriptor,
+                &revaultd.cpfp_descriptor,
+                db_vault.derivation_index,
+                revaultd
+                    .emergency_address
+                    .clone()
+                    .expect("Just checked we were a stakeholder"),
+                revaultd.lock_time,
+                &revaultd.secp_ctx,
+            )?;
+            emer_tx
+        };
+
+        return Ok(Some(unemer_tx.txid()));
+    }
+
+    Ok(None)
+}

--- a/src/daemon/control.rs
+++ b/src/daemon/control.rs
@@ -327,7 +327,9 @@ pub fn presigned_txs_list_from_outpoints(
         let mut emergency = None;
         let mut unvault_emergency = None;
         if revaultd.is_stakeholder() {
-            let (_, emer_psbt) = db_emer_transaction(db_path, db_vault.id)?;
+            // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
+            let (_, emer_psbt) = db_emer_transaction(db_path, db_vault.id)?
+                .expect("Must be here post 'Funded' state");
             let mut finalized_emer = emer_psbt.clone();
             emergency = Some(VaultPresignedTransaction {
                 transaction: if finalized_emer.finalize(&revaultd.secp_ctx).is_ok() {
@@ -338,7 +340,9 @@ pub fn presigned_txs_list_from_outpoints(
                 psbt: emer_psbt,
             });
 
-            let (_, unemer_psbt) = db_unvault_emer_transaction(db_path, db_vault.id)?;
+            // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
+            let (_, unemer_psbt) = db_unvault_emer_transaction(db_path, db_vault.id)?
+                .expect("Must be here post 'Funded' state");
             let mut finalized_unemer = unemer_psbt.clone();
             unvault_emergency = Some(VaultPresignedTransaction {
                 transaction: if finalized_unemer.finalize(&revaultd.secp_ctx).is_ok() {
@@ -415,11 +419,17 @@ pub fn onchain_txs_list_from_outpoints(
                 let mut emergency = None;
                 let mut unvault_emergency = None;
                 if revaultd.is_stakeholder() {
-                    let emer = db_emer_transaction(db_path, db_vault.id)?.1;
+                    // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
+                    let emer = db_emer_transaction(db_path, db_vault.id)?
+                        .expect("Must be here post 'Funded' state")
+                        .1;
                     emergency =
                         bitcoind_wallet_tx(bitcoind_tx, emer.into_psbt().extract_tx().txid())?;
 
-                    let unemer = db_unvault_emer_transaction(db_path, db_vault.id)?.1;
+                    // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
+                    let unemer = db_unvault_emer_transaction(db_path, db_vault.id)?
+                        .expect("Must be here if not 'unconfirmed'")
+                        .1;
                     unvault_emergency =
                         bitcoind_wallet_tx(bitcoind_tx, unemer.into_psbt().extract_tx().txid())?;
                 }

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -423,6 +423,22 @@ pub fn db_unconfirm_cancel_dbtx(
     dbtx_downgrade(db_tx, vault_id, VaultStatus::Canceling)
 }
 
+/// Downgrade a vault from 'emergencied' to 'emergencying'
+pub fn db_unconfirm_emer_dbtx(
+    db_tx: &rusqlite::Transaction,
+    vault_id: u32,
+) -> Result<(), DatabaseError> {
+    dbtx_downgrade(db_tx, vault_id, VaultStatus::EmergencyVaulting)
+}
+
+/// Downgrade a vault from 'unvaultemergencied' to 'unvaultemergencying'
+pub fn db_unconfirm_unemer_dbtx(
+    db_tx: &rusqlite::Transaction,
+    vault_id: u32,
+) -> Result<(), DatabaseError> {
+    dbtx_downgrade(db_tx, vault_id, VaultStatus::UnvaultEmergencyVaulting)
+}
+
 fn db_status_from_unvault_txid(
     db_path: &PathBuf,
     unvault_txid: &Txid,
@@ -450,6 +466,7 @@ pub fn db_confirm_unvault(db_path: &PathBuf, unvault_txid: &Txid) -> Result<(), 
     db_status_from_unvault_txid(db_path, unvault_txid, VaultStatus::Unvaulted)
 }
 
+/// Mark a vault as being in the 'canceling' state, out of the Unvault txid
 pub fn db_cancel_unvault(db_path: &PathBuf, unvault_txid: &Txid) -> Result<(), DatabaseError> {
     db_status_from_unvault_txid(db_path, unvault_txid, VaultStatus::Canceling)
 }
@@ -472,6 +489,11 @@ pub fn db_spend_unvault(
     })
 }
 
+/// Mark a vault as being in the 'unvault_emergency_vaulting' state, out of the Unvault txid
+pub fn db_emer_unvault(db_path: &PathBuf, unvault_txid: &Txid) -> Result<(), DatabaseError> {
+    db_status_from_unvault_txid(db_path, unvault_txid, VaultStatus::UnvaultEmergencyVaulting)
+}
+
 fn db_mark_vault_as(
     db_path: &PathBuf,
     vault_id: u32,
@@ -488,12 +510,25 @@ fn db_mark_vault_as(
         Ok(())
     })
 }
+
 pub fn db_mark_spent_unvault(db_path: &PathBuf, vault_id: u32) -> Result<(), DatabaseError> {
     db_mark_vault_as(&db_path, vault_id, VaultStatus::Spent)
 }
 
 pub fn db_mark_canceled_unvault(db_path: &PathBuf, vault_id: u32) -> Result<(), DatabaseError> {
     db_mark_vault_as(&db_path, vault_id, VaultStatus::Canceled)
+}
+
+pub fn db_mark_emergencied_unvault(db_path: &PathBuf, vault_id: u32) -> Result<(), DatabaseError> {
+    db_mark_vault_as(&db_path, vault_id, VaultStatus::UnvaultEmergencyVaulted)
+}
+
+pub fn db_mark_emergencying_vault(db_path: &PathBuf, vault_id: u32) -> Result<(), DatabaseError> {
+    db_mark_vault_as(&db_path, vault_id, VaultStatus::EmergencyVaulting)
+}
+
+pub fn db_mark_emergencied_vault(db_path: &PathBuf, vault_id: u32) -> Result<(), DatabaseError> {
+    db_mark_vault_as(&db_path, vault_id, VaultStatus::EmergencyVaulted)
 }
 
 /// Mark that we actually signed this vault's revocation txs, and stored the signatures for it.

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -1000,7 +1000,8 @@ mod test {
             .unwrap();
         assert_eq!(stored_cancel_tx.inner_tx().inputs[0].partial_sigs.len(), 1);
 
-        let (tx_db_id, stored_emer_tx) = db_emer_transaction(&db_path, db_vault.id).unwrap();
+        let (tx_db_id, stored_emer_tx) =
+            db_emer_transaction(&db_path, db_vault.id).unwrap().unwrap();
         assert_eq!(stored_emer_tx.inner_tx().inputs[0].partial_sigs.len(), 0);
         let mut emer_tx = fresh_emer_tx.clone();
         revault_tx_add_dummy_sig(&mut emer_tx, 0);
@@ -1012,11 +1013,12 @@ mod test {
             &revaultd.secp_ctx,
         )
         .unwrap();
-        let (_, stored_emer_tx) = db_emer_transaction(&db_path, db_vault.id).unwrap();
+        let (_, stored_emer_tx) = db_emer_transaction(&db_path, db_vault.id).unwrap().unwrap();
         assert_eq!(stored_emer_tx.inner_tx().inputs[0].partial_sigs.len(), 1);
 
-        let (tx_db_id, stored_unemer_tx) =
-            db_unvault_emer_transaction(&db_path, db_vault.id).unwrap();
+        let (tx_db_id, stored_unemer_tx) = db_unvault_emer_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(stored_unemer_tx.inner_tx().inputs[0].partial_sigs.len(), 0);
         let mut unemer_tx = fresh_unemer_tx.clone();
         revault_tx_add_dummy_sig(&mut unemer_tx, 0);
@@ -1028,7 +1030,9 @@ mod test {
             &revaultd.secp_ctx,
         )
         .unwrap();
-        let (_, stored_unemer_tx) = db_unvault_emer_transaction(&db_path, db_vault.id).unwrap();
+        let (_, stored_unemer_tx) = db_unvault_emer_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(stored_unemer_tx.inner_tx().inputs[0].partial_sigs.len(), 1);
 
         let (tx_db_id, stored_unvault_tx) = db_unvault_transaction(&db_path, db_vault.id).unwrap();
@@ -1049,7 +1053,10 @@ mod test {
         // They can also be queried
         assert_eq!(
             emer_tx,
-            db_emer_transaction(&db_path, db_vault.id).unwrap().1
+            db_emer_transaction(&db_path, db_vault.id)
+                .unwrap()
+                .unwrap()
+                .1
         );
         assert_eq!(
             cancel_tx,
@@ -1061,6 +1068,7 @@ mod test {
         assert_eq!(
             unemer_tx,
             db_unvault_emer_transaction(&db_path, db_vault.id)
+                .unwrap()
                 .unwrap()
                 .1
         );
@@ -1075,11 +1083,15 @@ mod test {
             Ok(())
         })
         .unwrap();
-        db_emer_transaction(&db_path, db_vault.id).unwrap_err();
+        assert!(db_emer_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .is_none());
         assert!(db_cancel_transaction(&db_path, db_vault.id)
             .unwrap()
             .is_none());
-        db_unvault_emer_transaction(&db_path, db_vault.id).unwrap_err();
+        assert!(db_unvault_emer_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .is_none());
         db_unvault_transaction(&db_path, db_vault.id).unwrap_err();
 
         // And re-added of course

--- a/src/daemon/jsonrpc/api.rs
+++ b/src/daemon/jsonrpc/api.rs
@@ -1149,7 +1149,7 @@ impl RpcApi for RpcImpl {
             &spent_vaults,
         )
         .map_err(|e| {
-            JsonRpcError::invalid_params(format!("Broadcasting Unvault transaction(s): '{}'", e))
+            internal_error!(format!("Broadcasting Unvault transaction(s): '{}'", e))
         })?;
         db_mark_broadcastable_spend(&db_path, &spend_txid).map_err(|e| internal_error!(e))?;
 
@@ -1184,7 +1184,7 @@ impl RpcApi for RpcImpl {
             vault,
         )
         .map_err(|e| {
-            JsonRpcError::invalid_params(format!("Broadcasting Cancel transaction: '{}'", e))
+            internal_error!(format!("Broadcasting Cancel transaction: '{}'", e))
         })?;
 
         Ok(json!({}))

--- a/src/daemon/jsonrpc/api.rs
+++ b/src/daemon/jsonrpc/api.rs
@@ -482,8 +482,10 @@ impl RpcApi for RpcImpl {
                 db_txid, rpc_txid
             )));
         }
+        // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
         let (emer_db_id, db_emergency_tx) = db_emer_transaction(&revaultd.db_file(), db_vault.id)
-            .map_err(|e| internal_error!(e))?;
+            .map_err(|e| internal_error!(e))?
+            .expect("Must be here if 'funded'");
         let rpc_txid = emergency_tx.inner_tx().global.unsigned_tx.wtxid();
         let db_txid = db_emergency_tx.inner_tx().global.unsigned_tx.wtxid();
         if rpc_txid != db_txid {
@@ -492,9 +494,11 @@ impl RpcApi for RpcImpl {
                 db_txid, rpc_txid
             )));
         }
+        // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
         let (unvault_emer_db_id, db_unemergency_tx) =
             db_unvault_emer_transaction(&revaultd.db_file(), db_vault.id)
-                .map_err(|e| internal_error!(e))?;
+                .map_err(|e| internal_error!(e))?
+                .expect("Must be here if 'funded'");
         let rpc_txid = unvault_emergency_tx.inner_tx().global.unsigned_tx.wtxid();
         let db_txid = db_unemergency_tx.inner_tx().global.unsigned_tx.wtxid();
         if rpc_txid != db_txid {

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -7,7 +7,7 @@ mod sigfetcher;
 mod threadmessages;
 
 use crate::{
-    bitcoind::actions::{bitcoind_main_loop, start_bitcoind},
+    bitcoind::{bitcoind_main_loop, start_bitcoind},
     control::RpcUtils,
     database::actions::setup_db,
     jsonrpc::{

--- a/src/daemon/threadmessages.rs
+++ b/src/daemon/threadmessages.rs
@@ -9,7 +9,10 @@ pub enum BitcoindMessageOut {
     Shutdown,
     SyncProgress(SyncSender<f64>),
     WalletTransaction(Txid, SyncSender<Option<WalletTransaction>>),
-    BroadcastTransaction(BitcoinTransaction, SyncSender<Result<(), BitcoindError>>),
+    BroadcastTransactions(
+        Vec<BitcoinTransaction>,
+        SyncSender<Result<(), BitcoindError>>,
+    ),
 }
 
 /// Outgoing to the signature fetcher thread

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -119,7 +119,7 @@ def bitcoind(directory):
     bitcoind = BitcoinD(bitcoin_dir=directory)
     bitcoind.startup()
 
-    bitcoind.rpc.createwallet(bitcoind.rpc.wallet_name, False, False, "", True)
+    bitcoind.rpc.createwallet(bitcoind.rpc.wallet_name, False, False, "", False, True)
 
     while bitcoind.rpc.getbalance() < 50:
         bitcoind.rpc.generatetoaddress(1, bitcoind.rpc.getnewaddress())
@@ -151,6 +151,8 @@ def revaultd_stakeholder(bitcoind, directory):
     stk_config = {
         "keychain": stks[0],
         "watchtowers": [{"host": "127.0.0.1:1", "noise_key": os.urandom(32)}],
+        # We use a dummy one since we don't use it anyways
+        "emergency_address": "bcrt1qewc2348370pgw8kjz8gy09z8xyh0d9fxde6nzamd3txc9gkmjqmq8m4cdq",
     }
     coordinator_noise_key = (
         "d91563973102454a7830137e92d0548bc83b4ea2799f1df04622ca1307381402"
@@ -192,6 +194,8 @@ def revaultd_manager(bitcoind, directory):
     man_config = {
         "keychain": mans[0],
         "cosigners": [{"host": "127.0.0.1:1", "noise_key": os.urandom(32)}],
+        # We use a dummy one since we don't use it anyways
+        "emergency_address": "bcrt1qewc2348370pgw8kjz8gy09z8xyh0d9fxde6nzamd3txc9gkmjqmq8m4cdq",
     }
     coordinator_noise_key = (
         "d91563973102454a7830137e92d0548bc83b4ea2799f1df04622ca1307381402"

--- a/tests/test_framework/revaultd.py
+++ b/tests/test_framework/revaultd.py
@@ -54,7 +54,7 @@ class Revaultd(TailableProc):
 
             f.write(f'coordinator_host = "127.0.0.1:{coordinator_port}"\n')
             f.write(f'coordinator_noise_key = "{coordinator_noise_key}"\n')
-            f.write("coordinator_poll_seconds = 2\n")
+            f.write("coordinator_poll_seconds = 5\n")
 
             f.write("[scripts_config]\n")
             f.write(f'deposit_descriptor = "{deposit_desc}"\n')
@@ -65,7 +65,7 @@ class Revaultd(TailableProc):
             f.write('network = "regtest"\n')
             f.write(f"cookie_path = '{bitcoind_cookie}'\n")
             f.write(f"addr = '127.0.0.1:{bitcoind.rpcport}'\n")
-            f.write("poll_interval_secs = 3\n")
+            f.write("poll_interval_secs = 10\n")
 
             if stk_config is not None:
                 f.write("[stakeholder_config]\n")

--- a/tests/test_framework/revaultd.py
+++ b/tests/test_framework/revaultd.py
@@ -78,11 +78,7 @@ class Revaultd(TailableProc):
                         f"\"{wt['noise_key'].hex()}\" }}, "
                     )
                 f.write("]\n")
-                # FIXME: eventually use a real one here
-                f.write(
-                    "emergency_address = "
-                    '"bcrt1qewc2348370pgw8kjz8gy09z8xyh0d9fxde6nzamd3txc9gkmjqmq8m4cdq"\n'
-                )
+                f.write(f"emergency_address = \"{stk_config['emergency_address']}\"\n")
 
             if man_config is not None:
                 f.write("[manager_config]\n")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1337,12 +1337,6 @@ def test_reorged_cancel(revault_network, bitcoind):
     # Here we go canceling everything again
     bitcoind.generate_block(1, wait_for_mempool=2)
     for w in stks + mans:
-        w.wait_for_logs(
-            [
-                "Unvault transaction at .* is now being canceled",
-                "Cancel tx .* was confirmed",
-            ]
-        )
         wait_for(
             lambda: w.rpc.listvaults([], [deposit])["vaults"][0]["status"] == "canceled"
         )
@@ -1704,12 +1698,6 @@ def test_spends_concurrent(revault_network, bitcoind):
             lambda: len(w.rpc.listvaults(["unvaulting"], deposits)["vaults"])
             == len(deposits)
         )
-        w.wait_for_logs(
-            [
-                f"The deposit utxo created via '{deposit}' was unvaulted"
-                for deposit in deposits
-            ]
-        )
     # We need a single confirmation to consider the Unvault transaction confirmed
     bitcoind.generate_block(1, wait_for_mempool=len(deposits))
     for w in revault_network.participants():
@@ -1810,12 +1798,6 @@ def test_spends_conflicting(revault_network, bitcoind):
     wait_for(
         lambda: len(man.rpc.listvaults(["unvaulting"], deposits_a)["vaults"])
         == len(deposits_a)
-    )
-    man.wait_for_logs(
-        [
-            f"The deposit utxo created via '{deposit}' was unvaulted"
-            for deposit in deposits_a
-        ]
     )
     # We need a single confirmation to consider the Unvault transaction confirmed
     bitcoind.generate_block(1, wait_for_mempool=len(deposits_a))


### PR DESCRIPTION
In a nutshell this:
- DRYs-up the code
- Re-organizes the module (poller thread code in poller.rs, utils.rs, farewell actions.rs)
- Fixes some intricate logic to keep "single transitions" (eg deposit -> unvaulting -> unvaulted)
- Some misc fixes and cleanups