### PR TITLE
Fix failed building wheel for psycopg2

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,5 +4,5 @@ pytest-xdist==1.31.0
 pytest-timeout==1.3.4
 ephemeral_port_reserve==1.1.1
 bip32==0.0.8
-psycopg2==2.8
+psycopg2-binary==2.9
 pynacl==1.4


### PR DESCRIPTION
[psycopg-binary vs psycopg](https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary),  `psycopg2-binary` contains compiled wheel-package with binary while `psycopg2` required a bunch of [prerequisites](https://pypi.org/project/psycopg2-binary/#:~:text=Building%20Psycopg%20requires%20a%20few%20prerequisites%20(a%20C%20compiler%2C%20some%20development%20packages)%3A%20please%20check%20the%20install%20and%20the%20faq%20documents%20in%20the%20doc%20dir%20or%20online%20for%20the%20details).
Was throwing error previously while installing dependencies for _functional tests_.

Credits:- @darosior 
