### PR TITLE
tests: update python-bip32 to 2.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,6 +3,6 @@ pytest==6.2
 pytest-xdist==1.31.0
 pytest-timeout==1.3.4
 ephemeral_port_reserve==1.1.1
-bip32==0.0.8
+bip32~=2.0
 psycopg2-binary==2.9
 pynacl==1.4

--- a/tests/test_framework/revault_network.py
+++ b/tests/test_framework/revault_network.py
@@ -90,7 +90,7 @@ class RevaultNetwork:
 
         # TODO: implement CPFP
         cpfp_xpubs = [
-            bip32.BIP32.from_seed(os.urandom(32)).get_master_xpub()
+            bip32.BIP32.from_seed(os.urandom(32)).get_xpub()
             for _ in range(len(mans_keychains))
         ]
         stks_xpubs = [stk.get_xpub() for stk in stks_keychains]

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -74,7 +74,7 @@ class User(Participant):
         super(User, self).__init__()
 
     def get_xpub(self):
-        return self.hd.get_master_xpub()
+        return self.hd.get_xpub()
 
     def sign_revocation_psbt(self, psbt_str, deriv_index):
         """Attach an ACP signature to the PSBT with the key at {deriv_index}"""


### PR DESCRIPTION
After the latest fixes uncovered by the new BIP's test vectors