### PR TITLE
New api method: gethistory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,9 +17,14 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "991984e3fd003e7ba02eb724f87a0f997b78677c46c0e91f8424ad7394c9886a"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "autocfg"
@@ -208,18 +213,18 @@ checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99cf782f0dc4372d26846bec3de7804ceb5df083c2d4462c0b8d2330e894fa8"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
  "hashbrown",
 ]
@@ -287,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.20.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d31059f22935e6c31830db5249ba2b7ecd54fd73a9909286f0a67aa55c2fbd"
+checksum = "abd5850c449b40bacb498b2bbdfaff648b1b055630073ba8db499caf2d0ea9f2"
 dependencies = [
  "cc",
  "pkg-config",
@@ -369,6 +374,12 @@ checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "pkg-config"
@@ -527,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.24.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38ee71cbab2c827ec0ac24e76f82eca723cee92c509a65f67dee393c25112"
+checksum = "8a82b0b91fad72160c56bf8da7a549b25d7c31109f52cc1437eac4c0ad2550a7"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -729,6 +740,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ log = "0.4"
 fern = "0.6"
 
 # DB stuff
-rusqlite = { version = "0.24", features = ["bundled", "unlock_notify"] }
+rusqlite = { version = "0.26", features = ["bundled", "unlock_notify"] }
 
 # For umask..
 libc = "0.2.80"

--- a/doc/API.md
+++ b/doc/API.md
@@ -421,11 +421,12 @@ of inflows and outflows net of any change amount (that is technically a transact
 
 #### Request
 
-| Field    | Type         | Description                                                          |
-| -------- | ------------ | -------------------------------------------------------------------- |
-| `cursor` | int          | Timestamp of the date to retrieve events after                       |
-| `limit`  | int          | Number of events to retrieve                                         |
-| `kind`   | string array | Type of the events to retrieve, can be `deposit`, `cancel`, `spend`  |
+| Field         | Type         | Description                                                          |
+| ------------- | ------------ | -------------------------------------------------------------------- |
+| `kind`        | string array | Type of the events to retrieve, can be `deposit`, `cancel`, `spend`  |
+| `start`       | int          | Timestamp of the date to retrieve events after                       |
+| `end`         | int          | Timestamp of the date to retrieve events before                      |
+| `limit`       | int          | Limit of events to retrieve                                          |
 
 #### Response
 
@@ -435,12 +436,14 @@ of inflows and outflows net of any change amount (that is technically a transact
 
 ##### Event Resource
 
-| Field    | Type   | Description                                                                              |
-| -------- | ------ | ---------------------------------------------------------------------------------------- |
-| `kind`   | string | Type of the event, can be `deposit`, `cancel`, `spend`                                   |
-| `date`   | int    | Timestamp of the event                                                                   |
-| `amount` | int    | Absolute amount in satoshis that is entering or exiting the wallet                       |
-| `fee`    | int    | Fee of the event transaction                                                             |
+| Field         | Type   | Description                                                                              |
+| ------------- | ------ | ---------------------------------------------------------------------------------------- |
+| `blockheight` | int    | Blockheight of the event final transaction                                               |
+| `txid`        | string | Hex string  of the event final transaction id                                            |
+| `kind`        | string | Type of the event, can be `deposit`, `cancel`, `spend`                                   |
+| `date`        | int    | Timestamp of the event                                                                   |
+| `amount`      | int    | Absolute amount in satoshis that is entering or exiting the wallet                       |
+| `fee`         | int    | Fee of the event transaction                                                             |
 
 
 ### `emergency`

--- a/src/daemon/control.rs
+++ b/src/daemon/control.rs
@@ -8,6 +8,7 @@ use crate::daemon::{
         interface::{
             db_cancel_transaction, db_emer_transaction, db_signed_emer_txs, db_signed_unemer_txs,
             db_unvault_emer_transaction, db_unvault_transaction, db_vault_by_deposit, db_vaults,
+            db_vaults_with_txids_between_date,
         },
         schema::{DbTransaction, DbVault},
         DatabaseError,
@@ -25,8 +26,11 @@ use revault_net::{
 };
 use revault_tx::{
     bitcoin::{
-        consensus::encode, hashes::hex::ToHex, secp256k1, util::bip32::ChildNumber, Address,
-        Amount, OutPoint, Transaction as BitcoinTransaction, Txid,
+        consensus::encode,
+        hashes::hex::{FromHex, ToHex},
+        secp256k1,
+        util::bip32::ChildNumber,
+        Address, Amount, OutPoint, Transaction as BitcoinTransaction, Txid,
     },
     miniscript::DescriptorTrait,
     transactions::{
@@ -36,8 +40,9 @@ use revault_tx::{
 };
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     fmt,
+    path::Path,
     sync::{mpsc::Sender, Arc, RwLock},
     thread::JoinHandle,
 };
@@ -730,6 +735,171 @@ pub fn watchtowers_status(revaultd: &RevaultD) -> Vec<ServerStatus> {
     watchtowers
 }
 
+/// get_history retrieves a limited event which occured between two given dates.
+pub fn get_history<T: BitcoindThread>(
+    db_path: &Path,
+    bitcoind_conn: &T,
+    start: u64,
+    end: u64,
+    limit: u64,
+    kind: Vec<HistoryEventKind>,
+) -> Result<Vec<HistoryEvent>, RpcControlError> {
+    // the vaults retrieved are ALL vaults concerned by the limited txids that happened
+    // between the date. This list of vault includes then maybe some vaults that are
+    // a change of a spend or and a cancel and that were consumed again later
+    // outside of the date range.
+    let vaults = db_vaults_with_txids_between_date(&db_path, start, end, limit)?;
+
+    let mut spends: HashMap<Txid, u64> = HashMap::new();
+    let mut events: Vec<HistoryEvent> = Vec::new();
+
+    for vault in &vaults {
+        if kind.contains(&HistoryEventKind::Deposit)
+            && vault.received_at as u64 >= start
+            && vault.received_at as u64 <= end
+            // Only deposits that are not a spend transaction change and not cancel output
+            // are considered as history events.
+            && !vaults.iter().any(|vlt| vlt.final_txid == Some(vault.deposit_outpoint.txid))
+        {
+            events.push(HistoryEvent {
+                kind: HistoryEventKind::Deposit,
+                date: vault.received_at,
+                blockheight: vault.blockheight,
+                amount: Some(vault.amount.as_sat()),
+                fee: None,
+                txid: vault.deposit_outpoint.txid,
+            });
+        }
+
+        if kind.contains(&HistoryEventKind::Cancel)
+            && vault.status == VaultStatus::Canceled
+            && vault.updated_at as u64 >= start
+            && vault.updated_at as u64 <= end
+        {
+            let txid = vault
+                .final_txid
+                .expect("Canceled vault must have a cancel txid");
+
+            let cancel_tx = bitcoind_conn
+                .wallet_tx(txid)?
+                .expect("Cancel tx should be here");
+
+            if cancel_tx.blockheight.is_none() {
+                // a reorg occured, the event does not count anymore
+                continue;
+            }
+
+            let change_amount = vaults
+                .iter()
+                .find(|vault| vault.deposit_outpoint.txid == txid)
+                // if the change output did not create a vault because of the dust limit
+                // the change_amount is equal to 0.
+                .map_or(0, |vault| vault.amount.as_sat());
+
+            events.push(HistoryEvent {
+                kind: HistoryEventKind::Cancel,
+                date: cancel_tx.received_time,
+                blockheight: cancel_tx.blockheight.expect("Tx should be confirmed"),
+                amount: None,
+                fee: Some(
+                    vault
+                        .amount
+                        .as_sat()
+                        .checked_sub(change_amount)
+                        .expect("Moved funds include funds going back"),
+                ),
+                txid,
+            });
+        }
+
+        // In order to fill the spend map, only vaults that are
+        // consumed between the two dates are kept.
+        if kind.contains(&HistoryEventKind::Spend)
+            && vault.status == VaultStatus::Spent
+            && vault.updated_at as u64 >= start
+            && vault.updated_at as u64 <= end
+        {
+            let txid = vault
+                .final_txid
+                .expect("Spent vault must have a spend txid");
+
+            if let Some(amount_moved) = spends.get_mut(&txid) {
+                *amount_moved += vault.amount.as_sat();
+            } else {
+                spends.insert(txid, vault.amount.as_sat());
+            }
+        }
+    }
+
+    if kind.contains(&HistoryEventKind::Spend) {
+        for (txid, amount_moved) in spends {
+            let spend_tx = bitcoind_conn
+                .wallet_tx(txid)?
+                .expect("Spend tx should be here");
+
+            if spend_tx.blockheight.is_none() {
+                // a reorg occured, the event does not count anymore
+                continue;
+            }
+
+            let bytes =
+                Vec::from_hex(&spend_tx.hex).expect("bitcoind returned a wrong transaction format");
+            let tx: BitcoinTransaction =
+                encode::deserialize(&bytes).expect("bitcoind returned a wrong transaction format");
+
+            let outputs_amount: u64 = tx.output.iter().map(|output| output.value).sum();
+
+            let change_amount = vaults
+                .iter()
+                .filter(|vault| vault.deposit_outpoint.txid == txid)
+                .fold(0, |acc, vault| acc + vault.amount.as_sat());
+
+            // amount is the total of the outputs amount minus the change amount.
+            let amount = outputs_amount
+                .checked_sub(change_amount)
+                .expect("Outputs amount includes the change output amount");
+
+            // fees is the total of the deposits minus the total of the spend outputs.
+            // Fees include then the unvaulting fees and the spend fees.
+            let fees = amount_moved
+                .checked_sub(outputs_amount)
+                .expect("Funds moving include funds going back");
+
+            events.push(HistoryEvent {
+                date: spend_tx.received_time,
+                blockheight: spend_tx.blockheight.expect("Tx should be confirmed"),
+                kind: HistoryEventKind::Spend,
+                amount: Some(amount),
+                fee: Some(fees),
+                txid,
+            })
+        }
+    }
+
+    events.sort_by(|a, b| b.date.cmp(&a.date));
+    Ok(events)
+}
+
+#[derive(Debug, Serialize)]
+pub struct HistoryEvent {
+    pub kind: HistoryEventKind,
+    pub date: u32,
+    pub blockheight: u32,
+    pub amount: Option<u64>,
+    pub fee: Option<u64>,
+    pub txid: Txid,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum HistoryEventKind {
+    #[serde(rename = "cancel")]
+    Cancel,
+    #[serde(rename = "deposit")]
+    Deposit,
+    #[serde(rename = "spend")]
+    Spend,
+}
+
 #[derive(Clone)]
 pub struct RpcUtils {
     pub revaultd: Arc<RwLock<RevaultD>>,
@@ -758,7 +928,7 @@ mod test {
         jsonrpc::UserRole,
         revaultd::{RevaultD, VaultStatus},
         setup_db,
-        utils::test_utils::{dummy_revaultd, test_datadir},
+        utils::test_utils::{dummy_revaultd, insert_vault_in_db, test_datadir, MockBitcoindThread},
     };
     use revault_net::{
         message, sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::gen_keypair,
@@ -2424,5 +2594,162 @@ mod test {
             })
             .unwrap();
         cli_thread.join().unwrap();
+    }
+
+    #[test]
+    fn test_get_history() {
+        let datadir = test_datadir();
+        let mut revaultd = dummy_revaultd(datadir.clone(), UserRole::ManagerStakeholder);
+        setup_db(&mut revaultd).unwrap();
+        let db_file = revaultd.db_file();
+
+        let cancel_tx_hex = "0200000000010158a2f36c1be4e32f59d26930f64c452c81ffb1fc66bb96e8ddb477f0bacfb6660000000000fdffffff011042f4050000000022002025bfbde3ae8bd9381b9ddb837acdab48a3110cbeb05e84cb57b28d77e27794480747304402201b4c8061cb2fb8c086fdedba3787cd30bc765b0f4ba47b22e3b37fe5289ded4602204da79a4637ad85c4d17f9a840c4b50336b7072f5ca482507d9d1070ecf7f105e812103d7c8e6ff708e052a15e4c23f16c7143c2b0c98473a7fd6c1d10850a274319a5a483045022100860539abb4a1172625fcdb913759c54364063a28d707c22204d18ec5b4ffeede0220442e1560b506da56cefd4e4d603c3381c036de777e264f923fe6d81e8d6870cb8121034c8ecf7547552e8c3ca3e0d1189f09b23b92bce3c73186800e7089230cecf6810000ed5121027cf27be4980b5945b1fb4594c0a9cef39278d8a8d59ad0f001acf72a45d17fea21029091080c1f00962c6ef10d0f5346d5aecab6f65543670aa78ae21520b8a3cd2221027fa470475563f20c96b997224fe86bc9564ccad9adb77e083ccd3bdfc94fe9ed53ae6476a914927ea7d35721b017ffed4941ec764b36f730faa288ac6b76a91416b43735b6c445fa5f279c2afa70bfaf375f075388ac6c93528767522102abe475b199ec3d62fa576faee16a334fdb86ffb26dce75becebaaedf328ac3fe21030f64b922aee2fd597f104bc6cb3b670f1ca2c6c49b1071a1a6c010575d94fe5a52af0112b26800000000";
+        let spend_tx_hex = "0200000001b4243a48b54cc360e754e0175a985a49b67cf4615d8523ec5aa46d42421cdf7d0000000000504200000280b2010000000000220020b9be8f8574f8da64bb1cb6668f6134bc4706df7936eeab8411f9d82de20a895b08280954020000000000000000";
+
+        let cancel_tx: BitcoinTransaction =
+            encode::deserialize(&Vec::from_hex(cancel_tx_hex).unwrap()).unwrap();
+
+        let spend_tx: BitcoinTransaction =
+            encode::deserialize(&Vec::from_hex(spend_tx_hex).unwrap()).unwrap();
+
+        let deposit1_txid =
+            Txid::from_str("fcb6ab963b654c773de786f4ac92c132b3d2e816ccea37af9592aa0b4aaec04b")
+                .unwrap();
+
+        let deposit2_txid =
+            Txid::from_str("cafa9f92be48ba41f9ee67e775b6c4afebd1bdbde5758792e9f30f6dea41e7fb")
+                .unwrap();
+
+        insert_vault_in_db(
+            &db_file,
+            1,
+            &OutPoint::new(deposit1_txid, 0),
+            &Amount::ONE_BTC,
+            1,
+            ChildNumber::from_normal_idx(0).unwrap(),
+            1,
+            2,
+            VaultStatus::Canceled,
+            Some(&cancel_tx.txid()),
+        );
+
+        insert_vault_in_db(
+            &db_file,
+            1,
+            &OutPoint::new(cancel_tx.txid(), 0),
+            &Amount::from_sat(cancel_tx.output[0].value),
+            2,
+            ChildNumber::from_normal_idx(1).unwrap(),
+            2,
+            2,
+            VaultStatus::Funded,
+            None,
+        );
+
+        insert_vault_in_db(
+            &db_file,
+            1,
+            &OutPoint::new(deposit2_txid, 0),
+            &Amount::from_sat(200_000_000_000),
+            1,
+            ChildNumber::from_normal_idx(0).unwrap(),
+            3,
+            4,
+            VaultStatus::Spent,
+            Some(&spend_tx.txid()),
+        );
+
+        // change of the spend
+        insert_vault_in_db(
+            &db_file,
+            1,
+            &OutPoint::new(spend_tx.txid(), 0),
+            &Amount::from_sat(spend_tx.output[0].value),
+            2,
+            ChildNumber::from_normal_idx(1).unwrap(),
+            4,
+            4,
+            VaultStatus::Funded,
+            None,
+        );
+
+        let mut txs = HashMap::new();
+        txs.insert(
+            cancel_tx.txid(),
+            WalletTransaction {
+                hex: cancel_tx_hex.to_string(),
+                received_time: 2,
+                blockheight: Some(2),
+            },
+        );
+        txs.insert(
+            spend_tx.txid(),
+            WalletTransaction {
+                hex: spend_tx_hex.to_string(),
+                received_time: 4,
+                blockheight: Some(4),
+            },
+        );
+        let bitcoind_conn = MockBitcoindThread::new(txs);
+
+        let events = get_history(
+            &db_file,
+            &bitcoind_conn,
+            0,
+            4,
+            20,
+            vec![
+                HistoryEventKind::Deposit,
+                HistoryEventKind::Cancel,
+                HistoryEventKind::Spend,
+            ],
+        )
+        .unwrap();
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].txid, spend_tx.txid());
+        assert_eq!(events[0].kind, HistoryEventKind::Spend);
+        assert_eq!(events[0].amount.unwrap(), spend_tx.output[1].value);
+        assert_eq!(
+            events[0].fee.unwrap(),
+            200_000_000_000 - spend_tx.output[0].value - spend_tx.output[1].value,
+        );
+        assert_eq!(events[1].txid, deposit2_txid);
+        assert_eq!(events[1].kind, HistoryEventKind::Deposit);
+        assert_eq!(events[2].txid, cancel_tx.txid());
+        assert_eq!(events[2].kind, HistoryEventKind::Cancel);
+        assert!(events[2].amount.is_none());
+        assert_eq!(
+            events[2].fee.unwrap(),
+            Amount::ONE_BTC.as_sat() - cancel_tx.output[0].value
+        );
+        assert_eq!(events[3].txid, deposit1_txid);
+        assert_eq!(events[3].kind, HistoryEventKind::Deposit);
+
+        // retrieve events later in history
+        let events = get_history(
+            &db_file,
+            &bitcoind_conn,
+            0,
+            2,
+            20,
+            vec![
+                HistoryEventKind::Deposit,
+                HistoryEventKind::Cancel,
+                HistoryEventKind::Spend,
+            ],
+        )
+        .unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].txid, cancel_tx.txid());
+        assert_eq!(events[0].kind, HistoryEventKind::Cancel);
+        assert!(events[0].amount.is_none());
+        assert_eq!(
+            events[0].fee.unwrap(),
+            Amount::ONE_BTC.as_sat() - cancel_tx.output[0].value
+        );
+        assert_eq!(events[1].txid, deposit1_txid);
+        assert_eq!(events[1].kind, HistoryEventKind::Deposit);
+
+        fs::remove_dir_all(&datadir).unwrap_or_else(|_| ());
     }
 }

--- a/src/daemon/threadmessages.rs
+++ b/src/daemon/threadmessages.rs
@@ -21,7 +21,7 @@ pub enum SigFetcherMessageOut {
     Shutdown,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WalletTransaction {
     pub hex: String,
     // None if unconfirmed


### PR DESCRIPTION
`gethistory` retrieves the accounting events between two timestamps
The choice of removing the `limit` parameter in favor of a `lower_limit` timestamp is because of the need of retrieving a more large set of vaults in the sql query in order to be able to not count change and cancel outputs as deposit events

based on #280 