### PR TITLE
fix wrong error code of revocation sigs sharing

### DIFF
--- a/src/daemon/control.rs
+++ b/src/daemon/control.rs
@@ -737,7 +737,7 @@ pub fn share_rev_signatures(
         &UnvaultEmergencyTransaction,
         BTreeMap<BitcoinPubKey, Vec<u8>>,
     ),
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), CommunicationError> {
     // We would not spam the coordinator, would we?
     assert!(!cancel.1.is_empty() && !emer.1.is_empty() && !unvault_emer.1.is_empty());
     let mut transport = KKTransport::connect(coordinator_host, noise_secret, coordinator_noisekey)?;

--- a/src/daemon/jsonrpc/api/mod.rs
+++ b/src/daemon/jsonrpc/api/mod.rs
@@ -751,9 +751,7 @@ impl RpcApi for RpcImpl {
             (&emergency_tx, emer_sigs),
             (&unvault_emergency_tx, unvault_emer_sigs),
         )
-        .map_err(|e| {
-            JsonRpcError::invalid_params(format!("Error while sharing signatures: {}", e))
-        })?;
+        .map_err(|e| Error::from(e))?;
 
         // NOTE: it will only mark it as 'securing' if it was 'funded', not if it was
         // marked as 'secured' by db_update_presigned_tx() !


### PR DESCRIPTION
It returns a `invalid params` error code.
It should return a network communication error code.