### PR TITLE
Speed up the functional tests

### DIFF
--- a/tests/test_framework/revaultd.py
+++ b/tests/test_framework/revaultd.py
@@ -57,7 +57,7 @@ class Revaultd(TailableProc):
 
             f.write(f'coordinator_host = "127.0.0.1:{coordinator_port}"\n')
             f.write(f'coordinator_noise_key = "{coordinator_noise_key}"\n')
-            f.write("coordinator_poll_seconds = 5\n")
+            f.write("coordinator_poll_seconds = 1\n")
 
             f.write("[scripts_config]\n")
             f.write(f'deposit_descriptor = "{deposit_desc}"\n')
@@ -68,7 +68,7 @@ class Revaultd(TailableProc):
             f.write('network = "regtest"\n')
             f.write(f"cookie_path = '{bitcoind_cookie}'\n")
             f.write(f"addr = '127.0.0.1:{bitcoind.rpcport}'\n")
-            f.write("poll_interval_secs = 10\n")
+            f.write("poll_interval_secs = 1\n")
 
             if stk_config is not None:
                 f.write("[stakeholder_config]\n")


### PR DESCRIPTION
Analog to #287, based on #292.

The main bottlenecks for the test framework currently are:
- Waiting for vault status (activation, ..)
- Waiting for tx broadcast / conf acknowledgement

The former is limited by the Coordinator poll interval for signatures exchange and the latter by the bitcoind RPC poll interval for chainstate update. Reducing both drastically reduces the run time of the functional tests suite but reducing the bitcoind RPC poll interval currently is flaky on a race in the reorg tests, this is why it's still a draft.

On my machine this speeds up the tests from taking ~12min to ~6min (will edit shortly).