### PR TITLE
Presigned txs update overhaul

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ task:
     image: rust:latest
 
   env:
-    EXECUTOR_WORKERS: 8
+    EXECUTOR_WORKERS: 1
     VERBOSE: 1
     LOG_LEVEL: debug
     TIMEOUT: 300

--- a/src/daemon/bitcoind/poller.rs
+++ b/src/daemon/bitcoind/poller.rs
@@ -176,7 +176,11 @@ fn mark_unvaulted(
     unvaults_cache: &mut HashMap<OutPoint, UtxoInfo>,
     db_vault: &DbVault,
 ) -> Result<(), BitcoindError> {
-    let (_, unvault_tx) = db_unvault_transaction(&db_path, db_vault.id)?;
+    // FIXME: remove this unwrap in favour of an Error enum variant for txs not found
+    let unvault_tx = db_unvault_transaction(&db_path, db_vault.id)?
+        .unwrap()
+        .psbt
+        .assert_unvault();
     let unvault_descriptor = revaultd.read().unwrap().unvault_descriptor.derive(
         db_vault.derivation_index,
         &revaultd.read().unwrap().secp_ctx,

--- a/src/daemon/bitcoind/utils.rs
+++ b/src/daemon/bitcoind/utils.rs
@@ -183,8 +183,8 @@ pub fn cancel_txid(
     let revaultd = revaultd.read().unwrap();
     let db_path = revaultd.db_file();
 
-    let cancel_tx = if let Some((_, db_tx)) = db_cancel_transaction(&db_path, db_vault.id)? {
-        db_tx
+    let cancel_tx = if let Some(cancel_db_tx) = db_cancel_transaction(&db_path, db_vault.id)? {
+        cancel_db_tx.psbt.assert_cancel()
     } else {
         let (_, cancel_tx) = transaction_chain_manager(
             db_vault.deposit_outpoint,
@@ -212,8 +212,8 @@ pub fn unemer_txid(
 
     if revaultd.is_stakeholder() {
         let unemer_tx =
-            if let Some((_, db_tx)) = db_unvault_emer_transaction(&db_path, db_vault.id)? {
-                db_tx
+            if let Some(unemer_db_tx) = db_unvault_emer_transaction(&db_path, db_vault.id)? {
+                unemer_db_tx.psbt.assert_unvault_emer()
             } else {
                 let (_, _, _, unemer_tx) = transaction_chain(
                     db_vault.deposit_outpoint,
@@ -247,8 +247,8 @@ pub fn emer_txid(
     let db_path = revaultd.db_file();
 
     if revaultd.is_stakeholder() {
-        let unemer_tx = if let Some((_, db_tx)) = db_emer_transaction(&db_path, db_vault.id)? {
-            db_tx
+        let unemer_tx = if let Some(emer_db_tx) = db_emer_transaction(&db_path, db_vault.id)? {
+            emer_db_tx.psbt.assert_emer()
         } else {
             let (_, _, emer_tx, _) = transaction_chain(
                 db_vault.deposit_outpoint,

--- a/src/daemon/control.rs
+++ b/src/daemon/control.rs
@@ -777,11 +777,12 @@ mod test {
                 db_confirm_deposit, db_confirm_unvault, db_insert_new_unconfirmed_vault,
                 db_update_presigned_txs,
             },
+            bitcointx::RevaultTx,
             interface::{
                 db_cancel_transaction, db_emer_transaction, db_exec, db_unvault_emer_transaction,
                 db_unvault_transaction, db_vault_by_deposit,
             },
-            schema::{DbTransaction, DbVault, RevaultTx},
+            schema::{DbTransaction, DbVault},
         },
         jsonrpc::UserRole,
         revaultd::{RevaultD, VaultStatus},

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -1,7 +1,8 @@
 use crate::daemon::{
     database::{
+        bitcointx::{RevaultTx, TransactionType},
         interface::*,
-        schema::{DbTransaction, DbVault, RevaultTx, TransactionType, SCHEMA},
+        schema::{DbTransaction, DbVault, SCHEMA},
         DatabaseError, DB_VERSION,
     },
     revaultd::{BlockchainTip, RevaultD, VaultStatus},

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -1,16 +1,13 @@
 use crate::daemon::{
     database::{
         interface::*,
-        schema::{DbTransaction, RevaultTx, TransactionType, SCHEMA},
+        schema::{DbTransaction, DbVault, RevaultTx, TransactionType, SCHEMA},
         DatabaseError, DB_VERSION,
     },
     revaultd::{BlockchainTip, RevaultD, VaultStatus},
 };
 use revault_tx::{
-    bitcoin::{
-        consensus::encode, secp256k1, util::bip32::ChildNumber, Amount, OutPoint,
-        PublicKey as BitcoinPubKey, Txid,
-    },
+    bitcoin::{secp256k1, util::bip32::ChildNumber, Amount, OutPoint, Txid},
     miniscript::descriptor::DescriptorTrait,
     transactions::{
         CancelTransaction, EmergencyTransaction, RevaultTransaction, SpendTransaction,
@@ -19,7 +16,6 @@ use revault_tx::{
 };
 
 use std::{
-    collections::BTreeMap,
     convert::TryInto,
     fs,
     path::Path,
@@ -591,112 +587,131 @@ pub fn db_mark_activating_vault(db_path: &Path, vault_id: u32) -> Result<(), Dat
     })
 }
 
-fn revault_tx_merge_sigs(
-    tx: impl RevaultTransaction,
-    sigs: BTreeMap<BitcoinPubKey, Vec<u8>>,
-) -> Result<Vec<u8>, DatabaseError> {
-    let mut psbt = tx.into_psbt();
-    psbt.inputs[0].partial_sigs.extend(sigs);
-    Ok(encode::serialize(&psbt))
+// Merge the partial sigs of two transactions of the same type into the first one
+//
+// Returns true if this made the transaction "valid" (fully signed).
+fn revault_txs_merge_sigs<T, S>(tx_a: &mut T, tx_b: &T, secp: &secp256k1::Secp256k1<S>) -> bool
+where
+    T: RevaultTransaction,
+    S: secp256k1::Verification,
+{
+    for (pubkey, sig) in &tx_b.psbt().inputs[0].partial_sigs {
+        let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).expect("From DB");
+        tx_a.add_signature(0, pubkey.key, sig, secp)
+            .expect("From an in-DB PSBT");
+    }
+
+    tx_a.is_finalizable(secp)
 }
 
-/// Update the presigned transaction in-db. If the transaction is valid and no more revocation
-/// transactions are remaining unsigned for this vault, it will update the vault status as well in
-/// the same database transaction.
-pub fn db_update_presigned_tx(
+// Merge the signatures for two transactions into the first one
+//
+// The two transaction MUST be of the same type.
+fn db_txs_merge_sigs(
+    tx_a: &mut DbTransaction,
+    tx_b: &DbTransaction,
+    secp: &secp256k1::Secp256k1<impl secp256k1::Verification>,
+) -> bool {
+    assert_eq!(tx_a.tx_type, tx_b.tx_type);
+
+    match tx_a.psbt {
+        RevaultTx::Unvault(ref mut tx_a) => {
+            revault_txs_merge_sigs(tx_a, tx_b.psbt.unwrap_unvault(), secp)
+        }
+        RevaultTx::Cancel(ref mut tx_a) => {
+            revault_txs_merge_sigs(tx_a, tx_b.psbt.unwrap_cancel(), secp)
+        }
+        RevaultTx::Emergency(ref mut tx_a) => {
+            revault_txs_merge_sigs(tx_a, tx_b.psbt.unwrap_emer(), secp)
+        }
+        RevaultTx::UnvaultEmergency(ref mut tx_a) => {
+            revault_txs_merge_sigs(tx_a, tx_b.psbt.unwrap_unvault_emer(), secp)
+        }
+    }
+}
+
+/// Update the transactions of a given vault with the signatures of the given transactions.
+///
+/// The provided transactions MUST be valid, there signatures aren't checked.
+pub fn db_update_presigned_txs(
     db_path: &Path,
-    vault_id: u32,
-    tx_db_id: u32,
-    sigs: BTreeMap<BitcoinPubKey, Vec<u8>>,
-    secp_ctx: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    db_vault: &DbVault,
+    transactions: Vec<DbTransaction>,
+    secp: &secp256k1::Secp256k1<impl secp256k1::Verification>,
 ) -> Result<(), DatabaseError> {
     db_exec(db_path, move |db_tx| {
-        let mut is_unvault = false;
-
-        // Fetch the PSBT in the transaction, to avoid someone else to modify it under our feet..
-        let presigned_tx: DbTransaction = db_tx
-            .prepare("SELECT * FROM presigned_transactions WHERE id = (?1)")?
-            .query(params![tx_db_id])?
-            .next()?
-            .ok_or_else(|| {
-                DatabaseError(format!(
-                    "Transaction with id '{}' (vault id '{}') not found in db",
-                    tx_db_id, vault_id
-                ))
-            })?
-            .try_into()?;
-        // Now we are safe merging the signatures on what is the latest version of the PSBT
-        // FIXME: refactor this, it's awful
-        let (fully_signed, raw_psbt) = match presigned_tx.psbt {
-            RevaultTx::Cancel(tx) => {
-                let raw_psbt = revault_tx_merge_sigs(tx, sigs)?;
-                let fully_signed = CancelTransaction::from_raw_psbt(&raw_psbt)
-                    .expect("We just deserialized it")
-                    .is_finalizable(secp_ctx);
-                (fully_signed, raw_psbt)
-            }
-            RevaultTx::Emergency(tx) => {
-                let raw_psbt = revault_tx_merge_sigs(tx, sigs)?;
-                let fully_signed = EmergencyTransaction::from_raw_psbt(&raw_psbt)
-                    .expect("We just deserialized it")
-                    .is_finalizable(secp_ctx);
-                (fully_signed, raw_psbt)
-            }
-            RevaultTx::UnvaultEmergency(tx) => {
-                let raw_psbt = revault_tx_merge_sigs(tx, sigs)?;
-                let fully_signed = UnvaultEmergencyTransaction::from_raw_psbt(&raw_psbt)
-                    .expect("We just deserialized it")
-                    .is_finalizable(secp_ctx);
-                (fully_signed, raw_psbt)
-            }
-            RevaultTx::Unvault(tx) => {
-                is_unvault = true;
-                let raw_psbt = revault_tx_merge_sigs(tx, sigs)?;
-                let fully_signed = UnvaultTransaction::from_raw_psbt(&raw_psbt)
-                    .expect("We just deserialized it")
-                    .is_finalizable(secp_ctx);
-                (fully_signed, raw_psbt)
-            }
-        };
-
-        db_tx.execute(
-            "UPDATE presigned_transactions SET psbt = (?1), fullysigned = (?2) WHERE id = (?3)",
-            params![raw_psbt, fully_signed, tx_db_id],
-        )?;
-
-        if fully_signed {
-            // Are there some remaining unsigned revocation txs?
-            if db_tx
-                .prepare(
-                    "SELECT * FROM presigned_transactions WHERE fullysigned = 0 AND type != (?1) AND vault_id = (?2)",
-                )?
-                // All presigned transactions but the Unvault are revocation txs
-                .query(params![TransactionType::Unvault as u32, vault_id])?
+        for mut transaction in transactions {
+            // Merge the transaction with the in-db ones, in case another thread modified
+            // it under our feet.
+            let db_transaction: DbTransaction = db_tx
+                .prepare("SELECT * FROM presigned_transactions WHERE id = (?1)")?
+                .query(params![transaction.id])?
                 .next()?
-                .is_none()
-            {
-                // Nope. Mark the vault as 'secured'
-                db_tx
-                    .execute(
-                        "UPDATE vaults SET status = (?1), updated_at = strftime('%s','now') WHERE id = (?2) ",
-                        params![VaultStatus::Secured as u32, vault_id],
-                    )
-                    .map_err(|e| {
-                        DatabaseError(format!("Updating vault to 'secured': {}", e.to_string()))
-                    })?;
-            }
+                // Note this can happen if another thread removed them.
+                .ok_or_else(|| {
+                    DatabaseError(format!(
+                        "Transaction with id '{}' (vault id '{}') not found in db",
+                        transaction.id, db_vault.id
+                    ))
+                })?
+                .try_into()?;
+            let is_fully_signed = db_txs_merge_sigs(&mut transaction, &db_transaction, secp);
+            db_tx.execute(
+                "UPDATE presigned_transactions SET psbt = (?1), fullysigned = (?2) WHERE id = (?3)",
+                params![transaction.psbt.ser(), is_fully_signed, transaction.id],
+            )?;
+        }
 
-            // Was it the unvault that was fully signed ? If so, mark the vault as active.
-            if is_unvault {
-                db_tx
-                    .execute(
-                        "UPDATE vaults SET status = (?1), updated_at = strftime('%s','now') WHERE id = (?2) ",
-                        params![VaultStatus::Active as u32, vault_id],
-                    )
-                    .map_err(|e| {
-                        DatabaseError(format!("Updating vault to 'active': {}", e.to_string()))
-                    })?;
+        Ok(())
+    })
+}
+
+pub fn db_update_vault_status(db_path: &Path, db_vault: &DbVault) -> Result<(), DatabaseError> {
+    assert!(matches!(
+        db_vault.status,
+        VaultStatus::Unconfirmed
+            | VaultStatus::Funded
+            | VaultStatus::Securing
+            | VaultStatus::Secured
+            | VaultStatus::Activating
+    ));
+
+    db_exec(db_path, |db_tx| {
+        let db_transactions: Vec<DbTransaction> = db_tx
+            .prepare("SELECT * FROM presigned_transactions WHERE vault_id = (?1)")?
+            .query_map(params![db_vault.id], |row| row.try_into())?
+            .collect::<rusqlite::Result<Vec<DbTransaction>>>()?;
+
+        let (mut all_signed, mut all_but_unvault_signed) = (true, true);
+        for db_tx in db_transactions {
+            if !db_tx.is_fully_signed {
+                all_signed = false;
+                if !matches!(db_tx.tx_type, TransactionType::Unvault) {
+                    all_but_unvault_signed = false;
+                    break;
+                }
             }
+        }
+
+        if all_signed {
+            db_tx.execute(
+                "UPDATE vaults \
+                 SET status = (?1), updated_at = strftime('%s','now') \
+                 WHERE vaults.id = (?2)",
+                params![VaultStatus::Active as u32, db_vault.id],
+            )?;
+        } else if all_but_unvault_signed
+            && matches!(
+                db_vault.status,
+                VaultStatus::Unconfirmed | VaultStatus::Funded | VaultStatus::Securing
+            )
+        {
+            db_tx.execute(
+                "UPDATE vaults \
+                 SET status = (?1), updated_at = strftime('%s','now') \
+                 WHERE vaults.id = (?2)",
+                params![VaultStatus::Secured as u32, db_vault.id],
+            )?;
         }
 
         Ok(())
@@ -806,11 +821,14 @@ mod test {
     use crate::daemon::jsonrpc::UserRole;
     use crate::daemon::utils::test_utils::{dummy_revaultd, test_datadir};
     use revault_tx::{
-        bitcoin::{Network, OutPoint, PrivateKey as BitcoinPrivKey, SigHashType},
+        bitcoin::{
+            Network, OutPoint, PrivateKey as BitcoinPrivKey, PublicKey as BitcoinPubKey,
+            SigHashType,
+        },
         transactions::{CancelTransaction, EmergencyTransaction, UnvaultEmergencyTransaction},
     };
 
-    use std::{fs, str::FromStr};
+    use std::{collections, fs, str::FromStr};
 
     fn create_keys(
         ctx: &secp256k1::Secp256k1<secp256k1::All>,
@@ -839,6 +857,35 @@ mod test {
         let signature = secp_ctx.sign(&signature_hash, &privkey.key);
         tx.add_signature(input_index, pubkey.key, signature, secp_ctx)
             .unwrap();
+    }
+
+    fn update_presigned_tx<C>(
+        db_path: &std::path::PathBuf,
+        db_vault: &DbVault,
+        mut db_tx: DbTransaction,
+        sigs: &collections::BTreeMap<BitcoinPubKey, Vec<u8>>,
+        secp: &secp256k1::Secp256k1<C>,
+    ) where
+        C: secp256k1::Verification,
+    {
+        for (key, sig) in sigs {
+            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).unwrap();
+            match db_tx.psbt {
+                RevaultTx::Unvault(ref mut tx) => {
+                    tx.add_signature(0, key.key, sig, secp).unwrap();
+                }
+                RevaultTx::Cancel(ref mut tx) => {
+                    tx.add_signature(0, key.key, sig, secp).unwrap();
+                }
+                RevaultTx::Emergency(ref mut tx) => {
+                    tx.add_signature(0, key.key, sig, secp).unwrap();
+                }
+                RevaultTx::UnvaultEmergency(ref mut tx) => {
+                    tx.add_signature(0, key.key, sig, secp).unwrap();
+                }
+            }
+        }
+        db_update_presigned_txs(db_path, db_vault, vec![db_tx], secp).unwrap();
     }
 
     #[test]
@@ -1039,10 +1086,15 @@ mod test {
         assert!(db_signed_unemer_txs(&db_path).unwrap().is_empty());
 
         // Sanity check we can add sigs to them now
-        let (tx_db_id, stored_cancel_tx) = db_cancel_transaction(&db_path, db_vault.id)
+        let stored_cancel_tx = db_cancel_transaction(&db_path, db_vault.id)
             .unwrap()
             .unwrap();
-        assert_eq!(stored_cancel_tx.psbt().inputs[0].partial_sigs.len(), 0);
+        assert_eq!(
+            stored_cancel_tx.psbt.unwrap_cancel().psbt().inputs[0]
+                .partial_sigs
+                .len(),
+            0
+        );
         let mut cancel_tx = fresh_cancel_tx.clone();
         revault_tx_add_sig(
             &mut cancel_tx,
@@ -1050,39 +1102,56 @@ mod test {
             SigHashType::AllPlusAnyoneCanPay,
             &secp_ctx,
         );
-        db_update_presigned_tx(
+        update_presigned_tx(
             &db_path,
-            db_vault.id,
-            tx_db_id,
-            cancel_tx.psbt().inputs[0].partial_sigs.clone(),
+            &db_vault,
+            stored_cancel_tx,
+            &cancel_tx.psbt().inputs[0].partial_sigs,
             &revaultd.secp_ctx,
-        )
-        .unwrap();
-        let (_, stored_cancel_tx) = db_cancel_transaction(&db_path, db_vault.id)
+        );
+        let stored_cancel_tx = db_cancel_transaction(&db_path, db_vault.id)
             .unwrap()
             .unwrap();
-        assert_eq!(stored_cancel_tx.psbt().inputs[0].partial_sigs.len(), 1);
+        assert_eq!(
+            stored_cancel_tx.psbt.unwrap_cancel().psbt().inputs[0]
+                .partial_sigs
+                .len(),
+            1
+        );
 
-        let (tx_db_id, stored_emer_tx) =
-            db_emer_transaction(&db_path, db_vault.id).unwrap().unwrap();
-        assert_eq!(stored_emer_tx.psbt().inputs[0].partial_sigs.len(), 0);
+        let stored_emer_tx = db_emer_transaction(&db_path, db_vault.id).unwrap().unwrap();
+        assert_eq!(
+            stored_emer_tx.psbt.unwrap_emer().psbt().inputs[0]
+                .partial_sigs
+                .len(),
+            0
+        );
         let mut emer_tx = fresh_emer_tx.clone();
         revault_tx_add_sig(&mut emer_tx, 0, SigHashType::AllPlusAnyoneCanPay, &secp_ctx);
-        db_update_presigned_tx(
+        update_presigned_tx(
             &db_path,
-            db_vault.id,
-            tx_db_id,
-            emer_tx.psbt().inputs[0].partial_sigs.clone(),
+            &db_vault,
+            stored_emer_tx,
+            &emer_tx.psbt().inputs[0].partial_sigs,
             &revaultd.secp_ctx,
-        )
-        .unwrap();
-        let (_, stored_emer_tx) = db_emer_transaction(&db_path, db_vault.id).unwrap().unwrap();
-        assert_eq!(stored_emer_tx.psbt().inputs[0].partial_sigs.len(), 1);
+        );
+        let stored_emer_tx = db_emer_transaction(&db_path, db_vault.id).unwrap().unwrap();
+        assert_eq!(
+            stored_emer_tx.psbt.unwrap_emer().psbt().inputs[0]
+                .partial_sigs
+                .len(),
+            1
+        );
 
-        let (tx_db_id, stored_unemer_tx) = db_unvault_emer_transaction(&db_path, db_vault.id)
+        let stored_unemer_tx = db_unvault_emer_transaction(&db_path, db_vault.id)
             .unwrap()
             .unwrap();
-        assert_eq!(stored_unemer_tx.psbt().inputs[0].partial_sigs.len(), 0);
+        assert_eq!(
+            stored_unemer_tx.psbt.unwrap_unvault_emer().psbt().inputs[0]
+                .partial_sigs
+                .len(),
+            0
+        );
         let mut unemer_tx = fresh_unemer_tx.clone();
         revault_tx_add_sig(
             &mut unemer_tx,
@@ -1090,33 +1159,50 @@ mod test {
             SigHashType::AllPlusAnyoneCanPay,
             &secp_ctx,
         );
-        db_update_presigned_tx(
+        update_presigned_tx(
             &db_path,
-            db_vault.id,
-            tx_db_id,
-            unemer_tx.psbt().inputs[0].partial_sigs.clone(),
+            &db_vault,
+            stored_unemer_tx,
+            &unemer_tx.psbt().inputs[0].partial_sigs,
             &revaultd.secp_ctx,
-        )
-        .unwrap();
-        let (_, stored_unemer_tx) = db_unvault_emer_transaction(&db_path, db_vault.id)
+        );
+        let stored_unemer_tx = db_unvault_emer_transaction(&db_path, db_vault.id)
             .unwrap()
             .unwrap();
-        assert_eq!(stored_unemer_tx.psbt().inputs[0].partial_sigs.len(), 1);
+        assert_eq!(
+            stored_unemer_tx.psbt.unwrap_unvault_emer().psbt().inputs[0]
+                .partial_sigs
+                .len(),
+            1
+        );
 
-        let (tx_db_id, stored_unvault_tx) = db_unvault_transaction(&db_path, db_vault.id).unwrap();
-        assert_eq!(stored_unvault_tx.psbt().inputs[0].partial_sigs.len(), 0);
+        let stored_unvault_tx = db_unvault_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored_unvault_tx.psbt.unwrap_unvault().psbt().inputs[0]
+                .partial_sigs
+                .len(),
+            0
+        );
         let mut unvault_tx = fresh_unvault_tx.clone();
         revault_tx_add_sig(&mut unvault_tx, 0, SigHashType::All, &secp_ctx);
-        db_update_presigned_tx(
+        update_presigned_tx(
             &db_path,
-            db_vault.id,
-            tx_db_id,
-            unvault_tx.psbt().inputs[0].partial_sigs.clone(),
+            &db_vault,
+            stored_unvault_tx,
+            &unvault_tx.psbt().inputs[0].partial_sigs,
             &revaultd.secp_ctx,
-        )
-        .unwrap();
-        let (_, stored_unvault_tx) = db_unvault_transaction(&db_path, db_vault.id).unwrap();
-        assert_eq!(stored_unvault_tx.psbt().inputs[0].partial_sigs.len(), 1);
+        );
+        let stored_unvault_tx = db_unvault_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored_unvault_tx.psbt.assert_unvault().psbt().inputs[0]
+                .partial_sigs
+                .len(),
+            1
+        );
 
         // They can also be queried
         assert_eq!(
@@ -1124,25 +1210,32 @@ mod test {
             db_emer_transaction(&db_path, db_vault.id)
                 .unwrap()
                 .unwrap()
-                .1
+                .psbt
+                .assert_emer()
         );
         assert_eq!(
             cancel_tx,
             db_cancel_transaction(&db_path, db_vault.id)
                 .unwrap()
                 .unwrap()
-                .1
+                .psbt
+                .assert_cancel()
         );
         assert_eq!(
             unemer_tx,
             db_unvault_emer_transaction(&db_path, db_vault.id)
                 .unwrap()
                 .unwrap()
-                .1
+                .psbt
+                .assert_unvault_emer()
         );
         assert_eq!(
             unvault_tx,
-            db_unvault_transaction(&db_path, db_vault.id).unwrap().1
+            db_unvault_transaction(&db_path, db_vault.id)
+                .unwrap()
+                .unwrap()
+                .psbt
+                .assert_unvault()
         );
         let sig_mis_map = db_sig_missing(&db_path).unwrap();
         assert_eq!(sig_mis_map.len(), 1);
@@ -1169,7 +1262,9 @@ mod test {
         assert!(db_unvault_emer_transaction(&db_path, db_vault.id)
             .unwrap()
             .is_none());
-        db_unvault_transaction(&db_path, db_vault.id).unwrap_err();
+        assert!(db_unvault_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .is_none());
 
         // And re-added of course
         db_confirm_deposit(
@@ -1279,7 +1374,7 @@ mod test {
         )
         .unwrap();
 
-        let (tx_db_id, _) = db_cancel_transaction(&db_path, db_vault.id)
+        let stored_cancel_tx = db_cancel_transaction(&db_path, db_vault.id)
             .unwrap()
             .unwrap();
         let mut cancel_tx = fresh_cancel_tx.clone();
@@ -1293,28 +1388,27 @@ mod test {
             let db_path = db_path.clone();
             let cancel_tx = cancel_tx.clone();
             let secp = revaultd.secp_ctx.clone();
+            let stored_cancel_tx_b = stored_cancel_tx.clone();
             move || {
                 for _ in 0..10 {
-                    db_update_presigned_tx(
+                    update_presigned_tx(
                         &db_path,
-                        db_vault.id,
-                        tx_db_id,
-                        cancel_tx.psbt().inputs[0].partial_sigs.clone(),
+                        &db_vault,
+                        stored_cancel_tx_b.clone(),
+                        &cancel_tx.psbt().inputs[0].partial_sigs,
                         &secp,
-                    )
-                    .unwrap();
+                    );
                 }
             }
         });
         for _ in 0..10 {
-            db_update_presigned_tx(
+            update_presigned_tx(
                 &db_path,
-                db_vault.id,
-                tx_db_id,
-                cancel_tx.psbt().inputs[0].partial_sigs.clone(),
+                &db_vault,
+                stored_cancel_tx.clone(),
+                &cancel_tx.psbt().inputs[0].partial_sigs,
                 &revaultd.secp_ctx,
-            )
-            .unwrap();
+            );
         }
         handle.join().unwrap();
         fs::remove_dir_all(&datadir).unwrap_or_else(|_| ());
@@ -1362,14 +1456,17 @@ mod test {
             None,
         )
         .unwrap();
-        db_update_presigned_tx(
+        let stored_unvault_tx = db_unvault_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .unwrap();
+        update_presigned_tx(
             &db_path,
-            db_vault.id,
-            db_unvault_transaction(&db_path, db_vault.id).unwrap().0,
-            fullysigned_unvault_tx.psbt().inputs[0].partial_sigs.clone(),
+            &db_vault,
+            stored_unvault_tx,
+            &fullysigned_unvault_tx.psbt().inputs[0].partial_sigs,
             &revaultd.secp_ctx,
-        )
-        .unwrap();
+        );
+        db_mark_vault_as(&db_path, db_vault.id, VaultStatus::Active).unwrap();
 
         // We can store a Spend tx spending a single unvault and query it
         let spend_tx = SpendTransaction::from_psbt_str("cHNidP8BAGcCAAAAAciTbKS43sH49TJWX6xJ+MxqWfNQhRl+vkttRZ9sLUkHAAAAAAClAQAAAoAyAAAAAAAAIgAggxumgjPgMj5oHWn8QkvKqPIN0N5nuAbyQ+FEgOJZpjygjAIAAAAAAAAAAAAAAAEBK0ANAwAAAAAAIgAgKb0SdnuqeHAJpRuZTbk3r81qbXpuHrMEmxT9Kph47HQBAwQBAAAAAQWqIQMfu47eLiYeHN6Y3C1Vk0ckgmWifMy5IUhaPHbNELV93axRh2R2qRTtiGxBD5KrMQQU6UGx2zsKMMf6nIisa3apFCDKte9IuDeF0D4GA/JRUNX4xgt+iKxsk1KHZ1IhAzTPPnjrvzPFmi+raNR6sY8WTt1KNusVwp82uWebzWDwIQKl21mZX7WAQhRvdhhwqUAuQfIemg9zkTCCyMQ+Q8CVFVKvAqUBsmgiBgISdvSXF40j3jrrANf62qWrbfNg1pxOUtUssvG1xWhsbQg1o7aZCgAAAAABASUhAx+7jt4uJh4c3pjcLVWTRySCZaJ8zLkhSFo8ds0QtX3drFGHIgICEnb0lxeNI9466wDX+tqlq23zYNacTlLVLLLxtcVobG0INaO2mQoAAAAAIgICEnb0lxeNI9466wDX+tqlq23zYNacTlLVLLLxtcVobG0INaO2mQoAAAAA").unwrap();
@@ -1450,14 +1547,17 @@ mod test {
             None,
         )
         .unwrap();
-        db_update_presigned_tx(
+        let stored_unvault_tx = db_unvault_transaction(&db_path, db_vault.id)
+            .unwrap()
+            .unwrap();
+        update_presigned_tx(
             &db_path,
-            db_vault.id,
-            db_unvault_transaction(&db_path, db_vault.id).unwrap().0,
-            fullysigned_unvault_tx.psbt().inputs[0].partial_sigs.clone(),
+            &db_vault,
+            stored_unvault_tx,
+            &fullysigned_unvault_tx.psbt().inputs[0].partial_sigs,
             &revaultd.secp_ctx,
-        )
-        .unwrap();
+        );
+        db_mark_vault_as(&db_path, db_vault.id, VaultStatus::Active).unwrap();
 
         let spend_tx_b = SpendTransaction::from_psbt_str("cHNidP8BAGcCAAAAAXHqOcTAJnPyXEF1cxFATe4S6yHLGZm+s0aj9mUTtKgVAAAAAACHGwAAAoAyAAAAAAAAIgAgAYLPNnsrzQaSg7aZR0JUgXHtO6bnZRehvxqxyzW5m5ygjAIAAAAAAAAAAAAAAAEBK0ANAwAAAAAAIgAgdS3fC7QX+PKWZBful8J229uixPOW012CYpKMH7rU8T4BAwQBAAAAAQWqIQLbrZUUxHTNBLySX7XjBBa5auxTfjuUSHxE3vJ1JXfdlaxRh2R2qRS8iuykW8lDZdRWXgK4UY0gLAkjX4isa3apFJ+lQ0Ybj4Eig7391TEtxikgP4DDiKxsk1KHZ1IhAqTEmYMxdjLU50wj/Hw9X2Pf7WRDSCnO4P4qpJ5h+PNOIQO2p8sldVsHhhEimy+ZW0E1L3vX5d9mqQ0d01XVdx3DWVKvAocbsmgiBgISdvSXF40j3jrrANf62qWrbfNg1pxOUtUssvG1xWhsbQg1o7aZCgAAAAABASUhAtutlRTEdM0EvJJfteMEFrlq7FN+O5RIfETe8nUld92VrFGHIgICEnb0lxeNI9466wDX+tqlq23zYNacTlLVLLLxtcVobG0INaO2mQoAAAAAIgICEnb0lxeNI9466wDX+tqlq23zYNacTlLVLLLxtcVobG0INaO2mQoAAAAA").unwrap();
         let spend_tx_b_inputs = &spend_tx_b.tx().input;

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -1144,6 +1144,15 @@ mod test {
             unvault_tx,
             db_unvault_transaction(&db_path, db_vault.id).unwrap().1
         );
+        let sig_mis_map = db_sig_missing(&db_path).unwrap();
+        assert_eq!(sig_mis_map.len(), 1);
+        assert_eq!(
+            sig_mis_map
+                .get(sig_mis_map.keys().next().unwrap())
+                .unwrap()
+                .len(),
+            4
+        );
 
         // And removed, if there is eg a reorg.
         db_exec(&db_path, |db_tx| {
@@ -1197,6 +1206,15 @@ mod test {
         .unwrap();
         assert_eq!(db_signed_emer_txs(&db_path).unwrap().len(), 1);
         assert!(db_signed_unemer_txs(&db_path).unwrap().is_empty());
+        let sig_mis_map = db_sig_missing(&db_path).unwrap();
+        assert_eq!(sig_mis_map.len(), 1);
+        assert_eq!(
+            sig_mis_map
+                .get(sig_mis_map.keys().next().unwrap())
+                .unwrap()
+                .len(),
+            3
+        );
         // If we mark the UnvaultEmergency transaction as fully signed and the vault as
         // Unvaulting, it'll get returned by the unemer fetcher instead.
         db_unvault_deposit(&db_path, &fresh_unvault_tx.txid()).unwrap();

--- a/src/daemon/database/bitcointx.rs
+++ b/src/daemon/database/bitcointx.rs
@@ -1,0 +1,164 @@
+/// This is where we regroup all logic related to the storage and management of
+/// in-DB pre-signed *Bitcoin* transactions (not to be confused with DB txs).
+use revault_tx::{
+    bitcoin::{secp256k1, Txid, Wtxid},
+    transactions::{
+        CancelTransaction, EmergencyTransaction, RevaultTransaction, UnvaultEmergencyTransaction,
+        UnvaultTransaction,
+    },
+};
+
+use std::convert::TryFrom;
+
+/// The type of the transaction, as stored in the "presigned_transactions" table
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TransactionType {
+    Unvault,
+    Cancel,
+    Emergency,
+    UnvaultEmergency,
+}
+
+impl TryFrom<u32> for TransactionType {
+    type Error = ();
+
+    fn try_from(n: u32) -> Result<Self, Self::Error> {
+        match n {
+            0 => Ok(Self::Unvault),
+            1 => Ok(Self::Cancel),
+            2 => Ok(Self::Emergency),
+            3 => Ok(Self::UnvaultEmergency),
+            _ => Err(()),
+        }
+    }
+}
+
+macro_rules! tx_type_from_tx {
+    ($tx:ident, $tx_type:ident) => {
+        impl From<&$tx> for TransactionType {
+            fn from(_: &$tx) -> Self {
+                Self::$tx_type
+            }
+        }
+    };
+}
+tx_type_from_tx!(UnvaultTransaction, Unvault);
+tx_type_from_tx!(CancelTransaction, Cancel);
+tx_type_from_tx!(EmergencyTransaction, Emergency);
+tx_type_from_tx!(UnvaultEmergencyTransaction, UnvaultEmergency);
+
+// FIXME: move it into its own file
+/// A transaction stored in the 'presigned_transactions' table
+#[derive(Debug, PartialEq, Clone)]
+pub enum RevaultTx {
+    Unvault(UnvaultTransaction),
+    Cancel(CancelTransaction),
+    Emergency(EmergencyTransaction),
+    UnvaultEmergency(UnvaultEmergencyTransaction),
+}
+
+impl RevaultTx {
+    /// Serialize in the PSBT format
+    pub fn ser(&self) -> Vec<u8> {
+        match self {
+            RevaultTx::Unvault(ref tx) => tx.as_psbt_serialized(),
+            RevaultTx::Cancel(ref tx) => tx.as_psbt_serialized(),
+            RevaultTx::Emergency(ref tx) => tx.as_psbt_serialized(),
+            RevaultTx::UnvaultEmergency(ref tx) => tx.as_psbt_serialized(),
+        }
+    }
+
+    /// Add a signature to a presigned transaction (always first index)
+    pub fn add_signature<C>(
+        &mut self,
+        secp: &secp256k1::Secp256k1<C>,
+        pubkey: secp256k1::PublicKey,
+        sig: secp256k1::Signature,
+    ) -> Result<Option<Vec<u8>>, revault_tx::error::InputSatisfactionError>
+    where
+        C: secp256k1::Verification,
+    {
+        match self {
+            RevaultTx::Unvault(ref mut tx) => tx.add_sig(pubkey, sig, secp),
+            RevaultTx::Cancel(ref mut tx) => tx.add_cancel_sig(pubkey, sig, secp),
+            RevaultTx::Emergency(ref mut tx) => tx.add_emer_sig(pubkey, sig, secp),
+            RevaultTx::UnvaultEmergency(ref mut tx) => tx.add_emer_sig(pubkey, sig, secp),
+        }
+    }
+
+    /// Get the txid of the inner tx of the PSBT
+    pub fn txid(&self) -> Txid {
+        match self {
+            RevaultTx::Unvault(ref tx) => tx.txid(),
+            RevaultTx::Cancel(ref tx) => tx.txid(),
+            RevaultTx::Emergency(ref tx) => tx.txid(),
+            RevaultTx::UnvaultEmergency(ref tx) => tx.txid(),
+        }
+    }
+
+    /// Get the wtxid of the inner tx of the PSBT
+    pub fn wtxid(&self) -> Wtxid {
+        match self {
+            RevaultTx::Unvault(ref tx) => tx.wtxid(),
+            RevaultTx::Cancel(ref tx) => tx.wtxid(),
+            RevaultTx::Emergency(ref tx) => tx.wtxid(),
+            RevaultTx::UnvaultEmergency(ref tx) => tx.wtxid(),
+        }
+    }
+
+    pub fn unwrap_unvault(&self) -> &UnvaultTransaction {
+        match self {
+            RevaultTx::Unvault(ref tx) => tx,
+            _ => unreachable!("It must be an unvault!"),
+        }
+    }
+
+    pub fn unwrap_cancel(&self) -> &CancelTransaction {
+        match self {
+            RevaultTx::Cancel(ref tx) => tx,
+            _ => unreachable!("it must be a cancel!"),
+        }
+    }
+
+    pub fn unwrap_emer(&self) -> &EmergencyTransaction {
+        match self {
+            RevaultTx::Emergency(ref tx) => tx,
+            _ => unreachable!("It must be an emer!"),
+        }
+    }
+
+    pub fn unwrap_unvault_emer(&self) -> &UnvaultEmergencyTransaction {
+        match self {
+            RevaultTx::UnvaultEmergency(ref tx) => tx,
+            _ => unreachable!("It must be an unvaultemer!"),
+        }
+    }
+
+    pub fn assert_unvault(self) -> UnvaultTransaction {
+        match self {
+            RevaultTx::Unvault(tx) => tx,
+            _ => unreachable!("It must be an unvault!"),
+        }
+    }
+
+    pub fn assert_cancel(self) -> CancelTransaction {
+        match self {
+            RevaultTx::Cancel(tx) => tx,
+            _ => unreachable!("it must be a cancel!"),
+        }
+    }
+
+    pub fn assert_emer(self) -> EmergencyTransaction {
+        match self {
+            RevaultTx::Emergency(tx) => tx,
+            _ => unreachable!("It must be an emer!"),
+        }
+    }
+
+    pub fn assert_unvault_emer(self) -> UnvaultEmergencyTransaction {
+        match self {
+            RevaultTx::UnvaultEmergency(tx) => tx,
+            _ => unreachable!("It must be an unvaultemer!"),
+        }
+    }
+}

--- a/src/daemon/database/interface.rs
+++ b/src/daemon/database/interface.rs
@@ -1,8 +1,7 @@
 use crate::daemon::{
     database::{
-        schema::{
-            DbSpendTransaction, DbTransaction, DbVault, DbWallet, RevaultTx, TransactionType,
-        },
+        bitcointx::{RevaultTx, TransactionType},
+        schema::{DbSpendTransaction, DbTransaction, DbVault, DbWallet},
         DatabaseError,
     },
     revaultd::{BlockchainTip, VaultStatus},

--- a/src/daemon/database/interface.rs
+++ b/src/daemon/database/interface.rs
@@ -686,8 +686,13 @@ pub fn db_sig_missing(
         db_path,
         "SELECT v.*, ptx.* \
          FROM presigned_transactions as ptx INNER JOIN vaults as v ON ptx.vault_id = v.id \
-         WHERE fullysigned = 0",
-        params![],
+         WHERE ptx.fullysigned = 0 AND v.status IN (?1, ?2, ?3, ?4)",
+        params![
+            VaultStatus::Funded as u32,
+            VaultStatus::Securing as u32,
+            VaultStatus::Secured as u32,
+            VaultStatus::Activating as u32
+        ],
         |row| {
             let db_vault: DbVault = row.try_into()?;
             let db_tx: DbTransaction = db_tx_from_row(row, 11)?;

--- a/src/daemon/database/mod.rs
+++ b/src/daemon/database/mod.rs
@@ -1,4 +1,5 @@
 pub mod actions;
+pub mod bitcointx;
 pub mod interface;
 pub mod schema;
 

--- a/src/daemon/database/schema.rs
+++ b/src/daemon/database/schema.rs
@@ -1,18 +1,15 @@
-use crate::daemon::revaultd::VaultStatus;
+use crate::daemon::{
+    database::bitcointx::{RevaultTx, TransactionType},
+    revaultd::VaultStatus,
+};
 use revault_tx::{
     bitcoin::{
-        secp256k1,
         util::bip32::{ChildNumber, ExtendedPubKey},
-        Amount, OutPoint, Txid, Wtxid,
+        Amount, OutPoint, Txid,
     },
     scripts::{CpfpDescriptor, DepositDescriptor, UnvaultDescriptor},
-    transactions::{
-        CancelTransaction, EmergencyTransaction, RevaultTransaction, SpendTransaction,
-        UnvaultEmergencyTransaction, UnvaultTransaction,
-    },
+    transactions::SpendTransaction,
 };
-
-use std::convert::TryFrom;
 
 pub const SCHEMA: &str = "\
 CREATE TABLE version (
@@ -144,159 +141,6 @@ pub struct DbVault {
     pub received_at: u32,
     pub updated_at: u32,
     pub final_txid: Option<Txid>,
-}
-
-/// The type of the transaction, as stored in the "presigned_transactions" table
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum TransactionType {
-    Unvault,
-    Cancel,
-    Emergency,
-    UnvaultEmergency,
-}
-
-impl TryFrom<u32> for TransactionType {
-    type Error = ();
-
-    fn try_from(n: u32) -> Result<Self, Self::Error> {
-        match n {
-            0 => Ok(Self::Unvault),
-            1 => Ok(Self::Cancel),
-            2 => Ok(Self::Emergency),
-            3 => Ok(Self::UnvaultEmergency),
-            _ => Err(()),
-        }
-    }
-}
-
-macro_rules! tx_type_from_tx {
-    ($tx:ident, $tx_type:ident) => {
-        impl From<&$tx> for TransactionType {
-            fn from(_: &$tx) -> Self {
-                Self::$tx_type
-            }
-        }
-    };
-}
-tx_type_from_tx!(UnvaultTransaction, Unvault);
-tx_type_from_tx!(CancelTransaction, Cancel);
-tx_type_from_tx!(EmergencyTransaction, Emergency);
-tx_type_from_tx!(UnvaultEmergencyTransaction, UnvaultEmergency);
-
-// FIXME: move it into its own file
-/// A transaction stored in the 'presigned_transactions' table
-#[derive(Debug, PartialEq, Clone)]
-pub enum RevaultTx {
-    Unvault(UnvaultTransaction),
-    Cancel(CancelTransaction),
-    Emergency(EmergencyTransaction),
-    UnvaultEmergency(UnvaultEmergencyTransaction),
-}
-
-impl RevaultTx {
-    /// Serialize in the PSBT format
-    pub fn ser(&self) -> Vec<u8> {
-        match self {
-            RevaultTx::Unvault(ref tx) => tx.as_psbt_serialized(),
-            RevaultTx::Cancel(ref tx) => tx.as_psbt_serialized(),
-            RevaultTx::Emergency(ref tx) => tx.as_psbt_serialized(),
-            RevaultTx::UnvaultEmergency(ref tx) => tx.as_psbt_serialized(),
-        }
-    }
-
-    /// Add a signature to a presigned transaction (always first index)
-    pub fn add_signature<C>(
-        &mut self,
-        secp: &secp256k1::Secp256k1<C>,
-        pubkey: secp256k1::PublicKey,
-        sig: secp256k1::Signature,
-    ) -> Result<Option<Vec<u8>>, revault_tx::error::InputSatisfactionError>
-    where
-        C: secp256k1::Verification,
-    {
-        match self {
-            RevaultTx::Unvault(ref mut tx) => tx.add_sig(pubkey, sig, secp),
-            RevaultTx::Cancel(ref mut tx) => tx.add_cancel_sig(pubkey, sig, secp),
-            RevaultTx::Emergency(ref mut tx) => tx.add_emer_sig(pubkey, sig, secp),
-            RevaultTx::UnvaultEmergency(ref mut tx) => tx.add_emer_sig(pubkey, sig, secp),
-        }
-    }
-
-    /// Get the txid of the inner tx of the PSBT
-    pub fn txid(&self) -> Txid {
-        match self {
-            RevaultTx::Unvault(ref tx) => tx.txid(),
-            RevaultTx::Cancel(ref tx) => tx.txid(),
-            RevaultTx::Emergency(ref tx) => tx.txid(),
-            RevaultTx::UnvaultEmergency(ref tx) => tx.txid(),
-        }
-    }
-
-    /// Get the wtxid of the inner tx of the PSBT
-    pub fn wtxid(&self) -> Wtxid {
-        match self {
-            RevaultTx::Unvault(ref tx) => tx.wtxid(),
-            RevaultTx::Cancel(ref tx) => tx.wtxid(),
-            RevaultTx::Emergency(ref tx) => tx.wtxid(),
-            RevaultTx::UnvaultEmergency(ref tx) => tx.wtxid(),
-        }
-    }
-
-    pub fn unwrap_unvault(&self) -> &UnvaultTransaction {
-        match self {
-            RevaultTx::Unvault(ref tx) => tx,
-            _ => unreachable!("It must be an unvault!"),
-        }
-    }
-
-    pub fn unwrap_cancel(&self) -> &CancelTransaction {
-        match self {
-            RevaultTx::Cancel(ref tx) => tx,
-            _ => unreachable!("it must be a cancel!"),
-        }
-    }
-
-    pub fn unwrap_emer(&self) -> &EmergencyTransaction {
-        match self {
-            RevaultTx::Emergency(ref tx) => tx,
-            _ => unreachable!("It must be an emer!"),
-        }
-    }
-
-    pub fn unwrap_unvault_emer(&self) -> &UnvaultEmergencyTransaction {
-        match self {
-            RevaultTx::UnvaultEmergency(ref tx) => tx,
-            _ => unreachable!("It must be an unvaultemer!"),
-        }
-    }
-
-    pub fn assert_unvault(self) -> UnvaultTransaction {
-        match self {
-            RevaultTx::Unvault(tx) => tx,
-            _ => unreachable!("It must be an unvault!"),
-        }
-    }
-
-    pub fn assert_cancel(self) -> CancelTransaction {
-        match self {
-            RevaultTx::Cancel(tx) => tx,
-            _ => unreachable!("it must be a cancel!"),
-        }
-    }
-
-    pub fn assert_emer(self) -> EmergencyTransaction {
-        match self {
-            RevaultTx::Emergency(tx) => tx,
-            _ => unreachable!("It must be an emer!"),
-        }
-    }
-
-    pub fn assert_unvault_emer(self) -> UnvaultEmergencyTransaction {
-        match self {
-            RevaultTx::UnvaultEmergency(tx) => tx,
-            _ => unreachable!("It must be an unvaultemer!"),
-        }
-    }
 }
 
 // FIXME: naming it "db transaction" was ambiguous..

--- a/src/daemon/database/schema.rs
+++ b/src/daemon/database/schema.rs
@@ -131,7 +131,7 @@ pub struct DbWallet {
 }
 
 /// A row of the "vaults" table
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DbVault {
     pub id: u32, // FIXME: should be an i64
     pub wallet_id: u32,

--- a/src/daemon/jsonrpc/api/error.rs
+++ b/src/daemon/jsonrpc/api/error.rs
@@ -32,6 +32,7 @@ impl From<RpcControlError> for Error {
             RpcControlError::Tx(_) => ErrorCode::INTERNAL_ERROR,
             RpcControlError::Bitcoind(_) => ErrorCode::BITCOIND_ERROR,
             RpcControlError::ThreadCommunication(_) => ErrorCode::INTERNAL_ERROR,
+            RpcControlError::TransactionNotFound => ErrorCode::INTERNAL_ERROR,
         };
         Error(code, e.to_string())
     }
@@ -70,6 +71,12 @@ impl From<RecvError> for Error {
 impl From<DatabaseError> for Error {
     fn from(e: DatabaseError) -> Error {
         Error(ErrorCode::INTERNAL_ERROR, e.to_string())
+    }
+}
+
+impl From<DatabaseError> for JsonRpcError {
+    fn from(e: DatabaseError) -> JsonRpcError {
+        Error::from(e).into()
     }
 }
 

--- a/src/daemon/jsonrpc/api/mod.rs
+++ b/src/daemon/jsonrpc/api/mod.rs
@@ -8,17 +8,16 @@ use error::Error;
 use crate::common::VERSION;
 use crate::daemon::{
     control::{
-        announce_spend_transaction, check_revocation_signatures, check_spend_transaction_size,
-        check_unvault_signatures, coordinator_status, cosigners_status, fetch_cosigs_signatures,
-        finalized_emer_txs, listvaults_from_db, onchain_txs, presigned_txs, share_rev_signatures,
-        share_unvault_signatures, vaults_from_deposits, watchtowers_status, ListSpendEntry,
-        ListSpendStatus, RpcUtils,
+        announce_spend_transaction, check_spend_transaction_size, coordinator_status,
+        cosigners_status, fetch_cosigs_signatures, finalized_emer_txs, listvaults_from_db,
+        onchain_txs, presigned_txs, share_rev_signatures, share_unvault_signatures,
+        vaults_from_deposits, watchtowers_status, ListSpendEntry, ListSpendStatus, RpcUtils,
     },
     database::{
         actions::{
             db_delete_spend, db_insert_spend, db_mark_activating_vault,
-            db_mark_broadcastable_spend, db_mark_securing_vault, db_update_presigned_tx,
-            db_update_spend,
+            db_mark_broadcastable_spend, db_mark_securing_vault, db_update_presigned_txs,
+            db_update_spend, db_update_vault_status,
         },
         interface::{
             db_cancel_transaction, db_emer_transaction, db_list_spends, db_spend_transaction,
@@ -577,37 +576,30 @@ impl RpcApi for RpcImpl {
         };
 
         // Sanity check they didn't send us garbaged PSBTs
-        // FIXME: this may not hold true in all cases, see https://github.com/revault/revaultd/issues/145
-        let (cancel_db_id, db_cancel_tx) = db_cancel_transaction(&db_path, db_vault.id)
-            .map_err(|e| Error::from(e))?
-            .expect("must be here if at least in 'Funded' state");
+        let mut cancel_db_tx = db_cancel_transaction(&db_path, db_vault.id)?
+            .ok_or_else(JsonRpcError::internal_error)?;
         let rpc_txid = cancel_tx.tx().wtxid();
-        let db_txid = db_cancel_tx.tx().wtxid();
+        let db_txid = cancel_db_tx.psbt.wtxid();
         if rpc_txid != db_txid {
             return Err(JsonRpcError::invalid_params(format!(
                 "Invalid Cancel tx: db wtxid is '{}' but this PSBT's is '{}' ",
                 db_txid, rpc_txid
             )));
         }
-        // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
-        let (emer_db_id, db_emergency_tx) = db_emer_transaction(&revaultd.db_file(), db_vault.id)
-            .map_err(|e| Error::from(e))?
-            .expect("Must be here if 'funded'");
+        let mut emer_db_tx = db_emer_transaction(&revaultd.db_file(), db_vault.id)?
+            .ok_or_else(JsonRpcError::internal_error)?;
         let rpc_txid = emergency_tx.tx().wtxid();
-        let db_txid = db_emergency_tx.tx().wtxid();
+        let db_txid = emer_db_tx.psbt.wtxid();
         if rpc_txid != db_txid {
             return Err(JsonRpcError::invalid_params(format!(
                 "Invalid Emergency tx: db wtxid is '{}' but this PSBT's is '{}' ",
                 db_txid, rpc_txid
             )));
         }
-        // FIXME: this *might* not hold true in all cases, see https://github.com/revault/revaultd/issues/145
-        let (unvault_emer_db_id, db_unemergency_tx) =
-            db_unvault_emer_transaction(&revaultd.db_file(), db_vault.id)
-                .map_err(|e| Error::from(e))?
-                .expect("Must be here if 'funded'");
+        let mut unvault_emer_db_tx = db_unvault_emer_transaction(&revaultd.db_file(), db_vault.id)?
+            .ok_or_else(JsonRpcError::internal_error)?;
         let rpc_txid = unvault_emergency_tx.tx().wtxid();
-        let db_txid = db_unemergency_tx.tx().wtxid();
+        let db_txid = unvault_emer_db_tx.psbt.wtxid();
         if rpc_txid != db_txid {
             return Err(JsonRpcError::invalid_params(format!(
                 "Invalid Unvault Emergency tx: db wtxid is '{}' but this PSBT's is '{}' ",
@@ -615,28 +607,26 @@ impl RpcApi for RpcImpl {
             )));
         }
 
+        // Alias some vars we'll reuse
         let deriv_index = db_vault.derivation_index;
-        let cancel_sigs = cancel_tx
+        let cancel_sigs = &cancel_tx
             .psbt()
             .inputs
             .get(0)
             .expect("Cancel tx has a single input, inbefore fee bumping.")
-            .partial_sigs
-            .clone();
-        let emer_sigs = emergency_tx
+            .partial_sigs;
+        let emer_sigs = &emergency_tx
             .psbt()
             .inputs
             .get(0)
             .expect("Emergency tx has a single input, inbefore fee bumping.")
-            .partial_sigs
-            .clone();
-        let unvault_emer_sigs = unvault_emergency_tx
+            .partial_sigs;
+        let unvault_emer_sigs = &unvault_emergency_tx
             .psbt()
             .inputs
             .get(0)
             .expect("UnvaultEmergency tx has a single input, inbefore fee bumping.")
-            .partial_sigs
-            .clone();
+            .partial_sigs;
 
         // They must have included *at least* a signature for our pubkey
         let our_pubkey = revaultd
@@ -688,66 +678,85 @@ impl RpcApi for RpcImpl {
             }
         }
 
-        // Don't share anything if we were given invalid signatures. This
-        // checks for the presence (and the validity!) of a SIGHASH type flag.
-        check_revocation_signatures(secp_ctx, &cancel_tx, &cancel_sigs).map_err(|e| {
-            JsonRpcError::invalid_params(format!("Invalid signature in Cancel transaction: {}", e))
-        })?;
-        check_revocation_signatures(secp_ctx, &emergency_tx, &emer_sigs).map_err(|e| {
-            JsonRpcError::invalid_params(format!(
-                "Invalid signature in Emergency transaction: {}",
-                e
-            ))
-        })?;
-        check_revocation_signatures(secp_ctx, &unvault_emergency_tx, &unvault_emer_sigs).map_err(
-            |e| {
-                JsonRpcError::invalid_params(format!(
-                    "Invalid signature in Unvault Emergency transaction: {}",
-                    e
-                ))
-            },
-        )?;
+        // Add the signatures to the DB transactions.
+        for (key, sig) in cancel_sigs {
+            if sig.is_empty() {
+                return Err(JsonRpcError::invalid_params(format!(
+                    "Empty signature for key '{}' in Cancel PSBT",
+                    key
+                )));
+            }
+            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+                JsonRpcError::invalid_params(format!("Non DER signature in Cancel PSBT"))
+            })?;
+            cancel_db_tx
+                .psbt
+                .add_signature(secp_ctx, key.key, sig)
+                .map_err(|e| {
+                    JsonRpcError::invalid_params(format!(
+                        "Invalid signature '{}' in Cancel PSBT: '{}'",
+                        sig, e
+                    ))
+                })?;
+        }
+        for (key, sig) in emer_sigs {
+            if sig.is_empty() {
+                return Err(JsonRpcError::invalid_params(format!(
+                    "Empty signature for key '{}' in Emergency PSBT",
+                    key
+                )));
+            }
+            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+                JsonRpcError::invalid_params(format!("Non DER signature in Emergency PSBT"))
+            })?;
+            emer_db_tx
+                .psbt
+                .add_signature(secp_ctx, key.key, sig)
+                .map_err(|e| {
+                    JsonRpcError::invalid_params(format!(
+                        "Invalid signature '{}' in Emergency PSBT: '{}'",
+                        sig, e
+                    ))
+                })?;
+        }
+        for (key, sig) in unvault_emer_sigs {
+            if sig.is_empty() {
+                return Err(JsonRpcError::invalid_params(format!(
+                    "Empty signature for key '{}' in UnvaultEmergency PSBT",
+                    key
+                )));
+            }
+            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+                JsonRpcError::invalid_params(format!("Non DER signature in UnvaultEmergency PSBT",))
+            })?;
+            unvault_emer_db_tx
+                .psbt
+                .add_signature(secp_ctx, key.key, sig)
+                .map_err(|e| {
+                    JsonRpcError::invalid_params(format!(
+                        "Invalid signature '{}' in UnvaultEmergency PSBT: '{}'",
+                        sig, e
+                    ))
+                })?;
+        }
 
-        // Ok, signatures look legit. Add them to the PSBTs in database.
-        db_update_presigned_tx(
-            &revaultd.db_file(),
-            db_vault.id,
-            cancel_db_id,
-            cancel_sigs.clone(),
-            secp_ctx,
-        )
-        .map_err(|e| Error::from(e))?;
-        db_update_presigned_tx(
-            &revaultd.db_file(),
-            db_vault.id,
-            emer_db_id,
-            emer_sigs.clone(),
-            secp_ctx,
-        )
-        .map_err(|e| Error::from(e))?;
-        db_update_presigned_tx(
-            &revaultd.db_file(),
-            db_vault.id,
-            unvault_emer_db_id,
-            unvault_emer_sigs.clone(),
-            secp_ctx,
-        )
-        .map_err(|e| Error::from(e))?;
+        // Then add them to the PSBTs in database. Take care to update the vault
+        // status if all signatures were given via the RPC.
+        let rev_txs = vec![cancel_db_tx, emer_db_tx, unvault_emer_db_tx];
+        db_update_presigned_txs(&db_path, &db_vault, rev_txs.clone(), secp_ctx)?;
+        db_mark_securing_vault(&db_path, db_vault.id)?;
+        db_update_vault_status(&db_path, &db_vault)?;
 
         // Share them with our felow stakeholders.
         share_rev_signatures(
             revaultd.coordinator_host,
             &revaultd.noise_secret,
             &revaultd.coordinator_noisekey,
-            (&cancel_tx, cancel_sigs),
-            (&emergency_tx, emer_sigs),
-            (&unvault_emergency_tx, unvault_emer_sigs),
+            (&cancel_tx, cancel_sigs.clone()),
+            (&emergency_tx, emer_sigs.clone()),
+            (&unvault_emergency_tx, unvault_emer_sigs.clone()),
         )
         .map_err(|e| Error::from(e))?;
-
-        // NOTE: it will only mark it as 'securing' if it was 'funded', not if it was
-        // marked as 'secured' by db_update_presigned_tx() !
-        db_mark_securing_vault(&db_path, db_vault.id).map_err(|e| Error::from(e))?;
 
         Ok(json!({}))
     }
@@ -813,18 +822,17 @@ impl RpcApi for RpcImpl {
         // better not send our unvault sig!
         // If the vault is already active (or more) there is no point in spamming the
         // coordinator.
-        let db_vault = db_vault_by_deposit(&db_path, &outpoint)
-            .map_err(|e| Error::from(e))?
-            .ok_or_else(|| unknown_outpoint!(outpoint))?;
+        let db_vault =
+            db_vault_by_deposit(&db_path, &outpoint)?.ok_or_else(|| unknown_outpoint!(outpoint))?;
         if !matches!(db_vault.status, VaultStatus::Secured) {
             return Err(invalid_status!(db_vault.status, VaultStatus::Funded));
         }
 
         // Sanity check they didn't send us a garbaged PSBT
-        let (unvault_db_id, db_unvault_tx) =
-            db_unvault_transaction(&db_path, db_vault.id).map_err(|e| Error::from(e))?;
+        let mut unvault_db_tx = db_unvault_transaction(&db_path, db_vault.id)?
+            .ok_or_else(JsonRpcError::internal_error)?;
         let rpc_txid = unvault_tx.tx().wtxid();
-        let db_txid = db_unvault_tx.tx().wtxid();
+        let db_txid = unvault_db_tx.psbt.wtxid();
         if rpc_txid != db_txid {
             return Err(JsonRpcError::invalid_params(format!(
                 "Invalid Unvault tx: db wtxid is '{}' but this PSBT's is '{}' ",
@@ -851,33 +859,40 @@ impl RpcApi for RpcImpl {
             )));
         }
 
-        // There is no reason for them to include an unnecessary signature, so be strict.
-        for (ref key, _) in sigs.iter() {
-            if !stk_keys.contains(key) {
+        for (key, sig) in sigs {
+            // There is no reason for them to include an unnecessary signature, so be strict.
+            if !stk_keys.contains(&key) {
                 return Err(JsonRpcError::invalid_params(format!(
-                    "Unknown key in Cancel transaction signatures: {}",
+                    "Unknown key in Unvault transaction signatures: {}",
                     key
                 )));
             }
+
+            if sig.is_empty() {
+                return Err(JsonRpcError::invalid_params(format!(
+                    "Empty signature for key '{}' in Unvault PSBT",
+                    key
+                )));
+            }
+            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+                JsonRpcError::invalid_params(format!("Non DER signature in Unvault PSBT"))
+            })?;
+
+            unvault_db_tx
+                .psbt
+                .add_signature(secp_ctx, key.key, sig)
+                .map_err(|e| {
+                    JsonRpcError::invalid_params(format!(
+                        "Invalid signature '{}' in Unvault PSBT: '{}'",
+                        sig, e
+                    ))
+                })?;
         }
 
-        // Of course, don't send a PSBT with an invalid signature
-        check_unvault_signatures(secp_ctx, &unvault_tx).map_err(|e| {
-            JsonRpcError::invalid_params(format!(
-                "Invalid signature in Unvault transaction: '{}'",
-                e
-            ))
-        })?;
-
         // Sanity checks passed. Store it then share it.
-        db_update_presigned_tx(
-            &revaultd.db_file(),
-            db_vault.id,
-            unvault_db_id,
-            sigs.clone(),
-            secp_ctx,
-        )
-        .map_err(|e| Error::from(e))?;
+        db_update_presigned_txs(&db_path, &db_vault, vec![unvault_db_tx.clone()], secp_ctx)?;
+        db_mark_activating_vault(&db_path, db_vault.id)?;
+        db_update_vault_status(&db_path, &db_vault)?;
         share_unvault_signatures(
             revaultd.coordinator_host,
             &revaultd.noise_secret,
@@ -890,10 +905,6 @@ impl RpcApi for RpcImpl {
                 e
             ))
         })?;
-
-        // NOTE: it will only mark it as 'unvaulting' if it was 'secured', not if it was
-        // marked as 'activated' by db_update_presigned_tx() !
-        db_mark_activating_vault(&db_path, db_vault.id).map_err(|e| Error::from(e))?;
 
         Ok(json!({}))
     }
@@ -1397,8 +1408,10 @@ impl RpcApi for RpcImpl {
             .values()
             .into_iter()
             .map(|db_vault| {
-                let (_, mut unvault_tx) =
-                    db_unvault_transaction(&db_path, db_vault.id).map_err(|e| Error::from(e))?;
+                let mut unvault_tx = db_unvault_transaction(&db_path, db_vault.id)?
+                    .ok_or_else(JsonRpcError::internal_error)?
+                    .psbt
+                    .assert_unvault();
                 unvault_tx
                     .finalize(&revaultd.secp_ctx)
                     .map_err(|e| Error::from(e))?;
@@ -1435,9 +1448,10 @@ impl RpcApi for RpcImpl {
             return Err(invalid_status!(vault.status, VaultStatus::Unvaulting));
         }
 
-        let (_, mut cancel_tx) = db_cancel_transaction(&db_path, vault.id)
-            .map_err(|e| Error::from(e))?
-            .expect("Must be in DB post 'Secured' status");
+        let mut cancel_tx = db_cancel_transaction(&db_path, vault.id)?
+            .ok_or_else(JsonRpcError::internal_error)?
+            .psbt
+            .assert_cancel();
 
         cancel_tx
             .finalize(&revaultd.secp_ctx)

--- a/src/daemon/jsonrpc/api/mod.rs
+++ b/src/daemon/jsonrpc/api/mod.rs
@@ -752,9 +752,7 @@ impl RpcApi for RpcImpl {
             revaultd.coordinator_host,
             &revaultd.noise_secret,
             &revaultd.coordinator_noisekey,
-            (&cancel_tx, cancel_sigs.clone()),
-            (&emergency_tx, emer_sigs.clone()),
-            (&unvault_emergency_tx, unvault_emer_sigs.clone()),
+            &rev_txs,
         )
         .map_err(|e| Error::from(e))?;
 
@@ -897,7 +895,7 @@ impl RpcApi for RpcImpl {
             revaultd.coordinator_host,
             &revaultd.noise_secret,
             &revaultd.coordinator_noisekey,
-            &unvault_tx,
+            &unvault_db_tx,
         )
         .map_err(|e| {
             JsonRpcError::invalid_params(format!(

--- a/src/daemon/revaultd.rs
+++ b/src/daemon/revaultd.rs
@@ -35,7 +35,7 @@ use revault_tx::{
 
 /// The status of a [Vault], depends both on the block chain and the set of pre-signed
 /// transactions
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum VaultStatus {
     /// The deposit transaction has less than 6 confirmations
     Unconfirmed,

--- a/src/daemon/sigfetcher.rs
+++ b/src/daemon/sigfetcher.rs
@@ -3,8 +3,9 @@ use crate::daemon::{
     control::{get_presigs, CommunicationError},
     database::{
         actions::{db_update_presigned_txs, db_update_vault_status},
+        bitcointx::RevaultTx,
         interface::db_sig_missing,
-        schema::{DbTransaction, DbVault, RevaultTx},
+        schema::{DbTransaction, DbVault},
         DatabaseError,
     },
     revaultd::RevaultD,

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -38,7 +38,7 @@ DEFAULT_COORD_PATH = os.path.join(
     "..",
     "servers",
     "coordinatord",
-    "target/debug/main",
+    "target/debug/coordinatord",
 )
 COORDINATORD_PATH = os.getenv("COORDINATORD_PATH", DEFAULT_COORD_PATH)
 DEFAULT_COSIG_PATH = os.path.join(


### PR DESCRIPTION
This is a complete refactor of our signature update for in-DB transactions. With the upcoming watchtower integration, it was not reasonable to pile on top of the intricate logic of `db_update_presigned_tx` in the coordinator poller thread.

This cleans up the signature update logic in the signature fetcher thread and as a consequence refactors the data structure used to represent the in-DB presigned transactions and the update of those via RPC.

It's a pretty invasive refactoring, but with some upsides as it fixes #284 and partially tackles #145 . Refer to the commit messages for more details.