### PR TITLE
Watchtower revocation signatures exchange

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -55,7 +55,9 @@ task:
     export REVAULTD_PATH=$PWD/target/release/revaultd
     git submodule update --init
     cd tests/servers
-    cd coordinatord && cargo build
+    cd miradord && cargo build
+    export MIRADORD_PATH=$PWD/target/debug/miradord
+    cd ../coordinatord && cargo build
     export COORDINATORD_PATH=$PWD/target/debug/coordinatord
     cd ../cosignerd && cargo build
     export COSIGNERD_PATH=$PWD/target/debug/cosignerd

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ task:
   matrix:
     - name: 'Misc functional tests'
       env:
-        TEST_GROUP: tests/test_misc.py
+        TEST_GROUP: tests/test_misc.py tests/test_watchtowers.py
     - name: 'RPC functional tests'
       env:
         TEST_GROUP: tests/test_rpc.py
@@ -23,9 +23,6 @@ task:
     - name: 'Spend functional tests'
       env:
         TEST_GROUP: tests/test_spend.py
-    - name: 'Watchtowers functional tests'
-      env:
-        TEST_GROUP: tests/test_watchtowers.py
 
   registry_cache:
     folder: $CARGO_HOME/registry

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,6 +23,9 @@ task:
     - name: 'Spend functional tests'
       env:
         TEST_GROUP: tests/test_spend.py
+    - name: 'Watchtowers functional tests'
+      env:
+        TEST_GROUP: tests/test_watchtowers.py
 
   registry_cache:
     folder: $CARGO_HOME/registry

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
-[submodule "tests/servers/coordinatord"]
+[submodule "coordinatord"]
 	path = tests/servers/coordinatord
 	url = https://github.com/revault/coordinatord
-[submodule "tests/servers/cosignerd"]
+	branch = master
+[submodule "cosignerd"]
 	path = tests/servers/cosignerd
 	url = https://github.com/revault/cosignerd
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = tests/servers/cosignerd
 	url = https://github.com/revault/cosignerd
 	branch = master
+[submodule "miradord"]
+	path = tests/servers/miradord
+	url = https://github.com/revault/miradord
+	branch = master

--- a/contrib/tools/mscompiler/src/main.rs
+++ b/contrib/tools/mscompiler/src/main.rs
@@ -14,7 +14,7 @@ macro_rules! from_json {
         serde_json::from_str($str).unwrap_or_else(|e| {
             eprintln!("Failed to deserialize '{}' as JSON: '{}'", $str, e);
             process::exit(1);
-        });
+        })
     };
 }
 

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -683,6 +683,10 @@ pub fn db_update_vault_status(db_path: &Path, db_vault: &DbVault) -> Result<(), 
             .query_map(params![db_vault.id], |row| row.try_into())?
             .collect::<rusqlite::Result<Vec<DbTransaction>>>()?;
 
+        if db_transactions.is_empty() {
+            return Ok(());
+        }
+
         let (mut all_signed, mut all_but_unvault_signed) = (true, true);
         for db_tx in db_transactions {
             if !db_tx.is_fully_signed {

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -263,9 +263,9 @@ pub fn db_insert_new_unconfirmed_vault(
         tx.execute(
             "INSERT INTO vaults ( \
                 wallet_id, status, blockheight, deposit_txid, deposit_vout, amount, derivation_index, \
-                received_at, updated_at, final_txid \
+                received_at, updated_at, final_txid, emer_shared \
             ) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, 0)",
             params![
                 wallet_id,
                 VaultStatus::Unconfirmed as u32,
@@ -585,6 +585,18 @@ pub fn db_mark_activating_vault(db_path: &Path, vault_id: u32) -> Result<(), Dat
         .map_err(|e| DatabaseError(format!("Updating vault to 'securing': {}", e.to_string())))?;
 
         Ok(())
+    })
+}
+
+/// Mark a vault as having its Emergency signature already shared with the watchtowers.
+pub fn db_mark_emer_shared(db_path: &Path, db_vault: &DbVault) -> Result<(), DatabaseError> {
+    db_exec(db_path, |tx| {
+        tx.execute(
+            "UPDATE vaults SET emer_shared = 1 WHERE vaults.id = (?1)",
+            params![db_vault.id],
+        )
+        .map(|_| ())
+        .map_err(DatabaseError::from)
     })
 }
 
@@ -1328,6 +1340,21 @@ mod test {
         .unwrap();
         assert!(db_signed_emer_txs(&db_path).unwrap().is_empty());
         assert_eq!(db_signed_unemer_txs(&db_path).unwrap().len(), 1);
+
+        // Sanity check we can mark the Emergency as shared with the watchtowers
+        assert!(
+            !db_vault_by_deposit(&db_path, &db_vault.deposit_outpoint)
+                .unwrap()
+                .unwrap()
+                .emer_shared
+        );
+        db_mark_emer_shared(&db_path, &db_vault).unwrap();
+        assert!(
+            db_vault_by_deposit(&db_path, &db_vault.deposit_outpoint)
+                .unwrap()
+                .unwrap()
+                .emer_shared
+        );
 
         fs::remove_dir_all(&datadir).unwrap_or_else(|_| ());
     }

--- a/src/daemon/database/schema.rs
+++ b/src/daemon/database/schema.rs
@@ -45,6 +45,8 @@ CREATE TABLE wallets (
  * spending txid or the canceling txid out of a deposit outpoint.
  * It MUST be NOT NULL if status is 'spending', 'spent', 'canceling'
  * or 'canceled'.
+ * The emer_shared field indicates wether we already shared the Emergency
+ * transaction for this vault with the watchtower.
  */
 CREATE TABLE vaults (
     id INTEGER PRIMARY KEY NOT NULL,
@@ -58,6 +60,7 @@ CREATE TABLE vaults (
     received_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL,
     final_txid BLOB,
+    emer_shared BOOLEAN NOT NULL CHECK (emer_shared IN (0,1)),
     FOREIGN KEY (wallet_id) REFERENCES wallets (id)
         ON UPDATE RESTRICT
         ON DELETE RESTRICT
@@ -141,6 +144,7 @@ pub struct DbVault {
     pub received_at: u32,
     pub updated_at: u32,
     pub final_txid: Option<Txid>,
+    pub emer_shared: bool,
 }
 
 // FIXME: naming it "db transaction" was ambiguous..

--- a/src/daemon/jsonrpc/api/error.rs
+++ b/src/daemon/jsonrpc/api/error.rs
@@ -14,12 +14,19 @@ impl From<CommunicationError> for Error {
     fn from(e: CommunicationError) -> Error {
         let code = match e {
             CommunicationError::Net(_) => ErrorCode::TRANSPORT_ERROR,
+            CommunicationError::WatchtowerNack(_, _) => ErrorCode::WT_SIG_NACK,
             CommunicationError::SignatureStorage => ErrorCode::COORDINATOR_SIG_STORE_ERROR,
             CommunicationError::SpendTxStorage => ErrorCode::COORDINATOR_SPEND_STORE_ERROR,
             CommunicationError::CosigAlreadySigned => ErrorCode::COSIGNER_ALREADY_SIGN_ERROR,
             CommunicationError::CosigInsanePsbt => ErrorCode::COSIGNER_INSANE_ERROR,
         };
         Error(code, e.to_string())
+    }
+}
+
+impl From<CommunicationError> for JsonRpcError {
+    fn from(e: CommunicationError) -> JsonRpcError {
+        Error::from(e).into()
     }
 }
 
@@ -96,6 +103,8 @@ pub enum ErrorCode {
     INTERNAL_ERROR = 11000,
     /// An error internal to revault_net, generally a transport error
     TRANSPORT_ERROR = 12000,
+    /// The watchtower refused our signatures
+    WT_SIG_NACK = 13_000,
     /// The Coordinator told us they could not store our signature
     COORDINATOR_SIG_STORE_ERROR = 13100,
     /// The Coordinator told us they could not store our Spend transaction

--- a/src/daemon/jsonrpc/api/mod.rs
+++ b/src/daemon/jsonrpc/api/mod.rs
@@ -8,10 +8,11 @@ use error::Error;
 use crate::common::VERSION;
 use crate::daemon::{
     control::{
-        announce_spend_transaction, check_spend_transaction_size, coordinator_status,
-        cosigners_status, fetch_cosigs_signatures, finalized_emer_txs, listvaults_from_db,
-        onchain_txs, presigned_txs, share_rev_signatures, share_unvault_signatures,
-        vaults_from_deposits, watchtowers_status, ListSpendEntry, ListSpendStatus, RpcUtils,
+        announce_spend_transaction, check_spend_transaction_size, coord_share_rev_signatures,
+        coordinator_status, cosigners_status, fetch_cosigs_signatures, finalized_emer_txs,
+        listvaults_from_db, onchain_txs, presigned_txs, share_unvault_signatures,
+        vaults_from_deposits, watchtowers_status, wts_share_emer_signatures, ListSpendEntry,
+        ListSpendStatus, RpcUtils,
     },
     database::{
         actions::{
@@ -745,10 +746,26 @@ impl RpcApi for RpcImpl {
         let rev_txs = vec![cancel_db_tx, emer_db_tx, unvault_emer_db_tx];
         db_update_presigned_txs(&db_path, &db_vault, rev_txs.clone(), secp_ctx)?;
         db_mark_securing_vault(&db_path, db_vault.id)?;
+
+        // If this made the Emergency fully signed and we are a stakeholder, share
+        // it with our watchtowers.
+        let emer_db_tx =
+            db_emer_transaction(&db_path, db_vault.id)?.ok_or(JsonRpcError::internal_error())?;
+        if !db_vault.emer_shared && emer_db_tx.psbt.unwrap_emer().is_finalizable(secp_ctx) {
+            if let Some(ref watchtowers) = revaultd.watchtowers {
+                wts_share_emer_signatures(
+                    &revaultd.noise_secret,
+                    &watchtowers,
+                    db_vault.deposit_outpoint,
+                    db_vault.derivation_index,
+                    &emer_db_tx,
+                )?;
+            }
+        }
         db_update_vault_status(&db_path, &db_vault)?;
 
         // Share them with our felow stakeholders.
-        share_rev_signatures(
+        coord_share_rev_signatures(
             revaultd.coordinator_host,
             &revaultd.noise_secret,
             &revaultd.coordinator_noisekey,

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,9 +59,9 @@ servers code:
 # From the root of the repository
 git submodule update --init --recursive
 cd tests/servers
-cd coordinatord && cargo build
-cd cosignerd && cargo build
-# TODO: add the other servers here when they are implemented
+cd coordinatord && cargo build && cd ..
+cd cosignerd && cargo build && cd ..
+cd miradord && cargo build && cd ..
 ```
 
 When you need a new version of the servers, you can update the submodules:

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,7 +47,7 @@ servers:
 
 ```
 # Adapt `-n`, `-v`, `timeout` and other environment variables to your needs
-pytest -vvv -n4 --timeout=1800
+pytest tests/ -vvv -n4 --ignore tests/servers/
 ```
 
 #### With the servers

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -150,7 +150,7 @@ def revaultd_stakeholder(bitcoind, directory):
 
     stk_config = {
         "keychain": stks[0],
-        "watchtowers": [{"host": "127.0.0.1:1", "noise_key": os.urandom(32)}],
+        "watchtowers": [{"host": "127.0.0.1:1", "noise_key": os.urandom(32).hex()}],
         # We use a dummy one since we don't use it anyways
         "emergency_address": "bcrt1qewc2348370pgw8kjz8gy09z8xyh0d9fxde6nzamd3txc9gkmjqmq8m4cdq",
     }

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -167,6 +167,7 @@ def revaultd_stakeholder(bitcoind, directory):
         reserve(),
         bitcoind,
         stk_config=stk_config,
+        wt_process=None,
     )
     revaultd.start()
 

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -109,7 +109,7 @@ def test_reorged_deposit(revaultd_stakeholder, bitcoind):
 def test_reorged_deposit_status(revault_network, bitcoind):
     # A csv of 2 because bitcoind would discard updating the mempool if the reorg is >10
     # blocks long.
-    revault_network.deploy(4, 2, csv=2)
+    revault_network.deploy(4, 2, csv=2, with_watchtowers=False)
     vault = revault_network.fund(0.14)
     revault_network.secure_vault(vault)
     deposit = f"{vault['txid']}:{vault['vout']}"
@@ -283,7 +283,7 @@ def test_reorged_deposit_status(revault_network, bitcoind):
 
 @pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
 def test_reorged_unvault(revault_network, bitcoind):
-    revault_network.deploy(4, 2, csv=12)
+    revault_network.deploy(4, 2, csv=12, with_watchtowers=False)
     man = revault_network.man(0)
     vaults = revault_network.fundmany([32, 3])
     deposits = []
@@ -410,7 +410,7 @@ def test_reorged_unvault(revault_network, bitcoind):
 
 @pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
 def test_reorged_cancel(revault_network, bitcoind):
-    revault_network.deploy(4, 2, csv=12)
+    revault_network.deploy(4, 2, csv=12, with_watchtowers=False)
     stks = revault_network.stks()
     mans = revault_network.mans()
     vault = revault_network.fund(32)

--- a/tests/test_framework/bitcoind.py
+++ b/tests/test_framework/bitcoind.py
@@ -76,14 +76,13 @@ class BitcoinD(TailableProc):
             "-datadir={}".format(bitcoin_dir),
             "-printtoconsole",
             "-server",
-            "-logtimestamps",
-            "-rpcthreads=16",
         ]
         bitcoind_conf = {
             "port": self.p2pport,
             "rpcport": rpcport,
             "debug": 1,
             "fallbackfee": Decimal(1000) / bitcoin.core.COIN,
+            "rpcthreads": 32,
         }
         self.conf_file = os.path.join(bitcoin_dir, "bitcoin.conf")
         with open(self.conf_file, "w") as f:

--- a/tests/test_framework/miradord.py
+++ b/tests/test_framework/miradord.py
@@ -111,3 +111,10 @@ class Miradord(TailableProc):
         conf["plugins"] += plugins
         open(self.conf_file, "w").write(toml.dumps(conf))
         self.start()
+
+    def remove_plugins(self, plugins_paths):
+        self.stop()
+        conf = toml.loads(open(self.conf_file, "r").read())
+        conf["plugins"] = [p for p in conf["plugins"] if p["path"] not in plugins_paths]
+        open(self.conf_file, "w").write(toml.dumps(conf))
+        self.start()

--- a/tests/test_framework/miradord.py
+++ b/tests/test_framework/miradord.py
@@ -1,0 +1,113 @@
+import logging
+import os
+import toml
+
+from test_framework.utils import (
+    TailableProc,
+    VERBOSE,
+    LOG_LEVEL,
+    MIRADORD_PATH,
+)
+from nacl.public import PrivateKey as Curve25519Private
+
+
+# FIXME: it's a bit clumsy. Miradord should stick to be the `miradord` process object
+# and we should have another class (PartialRevaultNetwork?) to stuff helpers and all
+# info not strictly necessary to running the process.
+class Miradord(TailableProc):
+    def __init__(
+        self,
+        datadir,
+        deposit_desc,
+        unvault_desc,
+        cpfp_desc,
+        emer_addr,
+        listen_port,
+        noise_priv,
+        stk_noise_key,
+        coordinator_noise_key,
+        coordinator_port,
+        bitcoind,
+        plugins=[],
+    ):
+        """All public keys must be hex"""
+        TailableProc.__init__(self, datadir, verbose=VERBOSE)
+
+        self.prefix = os.path.split(datadir)[-1]
+        self.noise_secret = noise_priv
+        self.listen_port = listen_port
+        self.deposit_desc = deposit_desc
+        self.unvault_desc = unvault_desc
+        self.cpfp_desc = cpfp_desc
+        self.emer_addr = emer_addr
+        self.bitcoind = bitcoind
+
+        # The data is stored in a per-network directory. We need to create it
+        # in order to write the Noise private key
+        self.datadir_with_network = os.path.join(datadir, "regtest")
+        os.makedirs(self.datadir_with_network, exist_ok=True)
+
+        self.conf_file = os.path.join(datadir, "config.toml")
+        self.cmd_line = [MIRADORD_PATH, "--conf", f"{self.conf_file}"]
+
+        self.noise_secret_file = os.path.join(self.datadir_with_network, "noise_secret")
+        with open(self.noise_secret_file, "wb") as f:
+            f.write(noise_priv)
+        wt_noise_key = bytes(Curve25519Private(noise_priv).public_key)
+        logging.debug(
+            f"Watchtower Noise key: {wt_noise_key.hex()}, Stakeholder Noise key: {stk_noise_key}"
+        )
+
+        bitcoind_cookie = os.path.join(bitcoind.bitcoin_dir, "regtest", ".cookie")
+        with open(self.conf_file, "w") as f:
+            f.write(f"data_dir = '{datadir}'\n")
+            f.write("daemon = false\n")
+            f.write(f"log_level = '{LOG_LEVEL}'\n")
+
+            f.write(f'stakeholder_noise_key = "{stk_noise_key}"\n')
+
+            f.write(f'coordinator_host = "127.0.0.1:{coordinator_port}"\n')
+            f.write(f'coordinator_noise_key = "{coordinator_noise_key}"\n')
+            f.write("coordinator_poll_seconds = 5\n")
+
+            f.write(f'listen = "127.0.0.1:{listen_port}"\n')
+
+            f.write("[scripts_config]\n")
+            f.write(f'deposit_descriptor = "{deposit_desc}"\n')
+            f.write(f'unvault_descriptor = "{unvault_desc}"\n')
+            f.write(f'cpfp_descriptor = "{cpfp_desc}"\n')
+            f.write(f'emergency_address = "{emer_addr}"\n')
+
+            f.write("[bitcoind_config]\n")
+            f.write('network = "regtest"\n')
+            f.write(f"cookie_path = '{bitcoind_cookie}'\n")
+            f.write(f"addr = '127.0.0.1:{bitcoind.rpcport}'\n")
+            f.write("poll_interval_secs = 5\n")
+
+            f.write(f"\n{toml.dumps({'plugins': plugins})}\n")
+
+    def start(self):
+        TailableProc.start(self)
+        self.wait_for_logs(
+            ["bitcoind now synced", "Listener thread started", "Started miradord."]
+        )
+
+    def stop(self, timeout=10):
+        return TailableProc.stop(self)
+
+    def cleanup(self):
+        try:
+            self.stop()
+        except Exception:
+            self.proc.kill()
+
+    def add_plugins(self, plugins):
+        """Takes a list of dict representing plugin config to add to the watchtower and
+        restarts it."""
+        self.stop()
+        conf = toml.loads(open(self.conf_file, "r").read())
+        if "plugins" not in conf:
+            conf["plugins"] = []
+        conf["plugins"] += plugins
+        open(self.conf_file, "w").write(toml.dumps(conf))
+        self.start()

--- a/tests/test_framework/revault_network.py
+++ b/tests/test_framework/revault_network.py
@@ -18,6 +18,7 @@ from test_framework.utils import (
     wait_for,
     RpcError,
     TIMEOUT,
+    WT_PLUGINS_DIR,
 )
 
 
@@ -220,6 +221,11 @@ class RevaultNetwork:
 
         # Start daemons in parallel, as it takes a few seconds for each
         start_jobs = []
+        # By default the watchtower should not revault anything
+        default_wt_plugin = {
+            "path": os.path.join(WT_PLUGINS_DIR, "revault_nothing.py"),
+            "conf": {},
+        }
 
         # Spin up the stakeholders wallets and their cosigning servers
         for i, stk in enumerate(stkonly_keychains):
@@ -238,6 +244,7 @@ class RevaultNetwork:
                 coordinator_noisepub.hex(),
                 self.coordinator_port,
                 self.bitcoind,
+                plugins=[default_wt_plugin],
             )
             start_jobs.append(self.executor.submit(miradord.start))
             self.daemons.append(miradord)
@@ -265,6 +272,7 @@ class RevaultNetwork:
                 self.coordinator_port,
                 self.bitcoind,
                 stk_config,
+                wt_process=miradord,
             )
             start_jobs.append(self.executor.submit(revaultd.start))
             self.stk_wallets.append(revaultd)
@@ -300,6 +308,7 @@ class RevaultNetwork:
                 coordinator_noisepub.hex(),
                 self.coordinator_port,
                 self.bitcoind,
+                plugins=[default_wt_plugin],
             )
             start_jobs.append(self.executor.submit(miradord.start))
             self.daemons.append(miradord)
@@ -332,6 +341,7 @@ class RevaultNetwork:
                 self.bitcoind,
                 stk_config,
                 man_config,
+                wt_process=miradord,
             )
             start_jobs.append(self.executor.submit(revaultd.start))
             self.stkman_wallets.append(revaultd)

--- a/tests/test_framework/revaultd.py
+++ b/tests/test_framework/revaultd.py
@@ -24,6 +24,7 @@ class Revaultd(TailableProc):
         bitcoind,
         stk_config=None,
         man_config=None,
+        wt_process=None,
     ):
         # set descriptors
         self.cpfp_desc = cpfp_desc
@@ -34,6 +35,7 @@ class Revaultd(TailableProc):
         TailableProc.__init__(self, datadir, verbose=VERBOSE)
 
         self.prefix = os.path.split(datadir)[-1]
+        self.watchtower = wt_process
 
         # The data is stored in a per-network directory. We need to create it
         # in order to write the Noise private key
@@ -198,6 +200,7 @@ class StakeholderRevaultd(Revaultd):
         coordinator_port,
         bitcoind,
         stk_config,
+        wt_process,
     ):
         """The wallet daemon for a stakeholder.
         Needs to know all xpubs, and needs to be able to connect to the
@@ -214,6 +217,7 @@ class StakeholderRevaultd(Revaultd):
             bitcoind,
             stk_config,
             man_config=None,
+            wt_process=wt_process,
         )
         assert self.stk_keychain is not None
 
@@ -231,6 +235,7 @@ class StkManRevaultd(Revaultd):
         bitcoind,
         stk_config,
         man_config,
+        wt_process,
     ):
         """A revaultd instance that is both stakeholder and manager."""
         super(StkManRevaultd, self).__init__(
@@ -244,4 +249,5 @@ class StkManRevaultd(Revaultd):
             bitcoind,
             stk_config,
             man_config,
+            wt_process,
         )

--- a/tests/test_framework/revaultd.py
+++ b/tests/test_framework/revaultd.py
@@ -78,7 +78,7 @@ class Revaultd(TailableProc):
                 for wt in stk_config["watchtowers"]:
                     f.write(
                         f"{{ \"host\" = \"{wt['host']}\", \"noise_key\" = "
-                        f"\"{wt['noise_key'].hex()}\" }}, "
+                        f"\"{wt['noise_key']}\" }}, "
                     )
                 f.write("]\n")
                 f.write(f"emergency_address = \"{stk_config['emergency_address']}\"\n")

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -33,6 +33,14 @@ DEFAULT_REV_PATH = os.path.join(
     os.path.dirname(__file__), "..", "..", "target/debug/revaultd"
 )
 REVAULTD_PATH = os.getenv("REVAULTD_PATH", DEFAULT_REV_PATH)
+DEFAULT_MIRADORD_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "servers",
+    "miradord",
+    "target/debug/miradord",
+)
+MIRADORD_PATH = os.getenv("MIRADORD_PATH", DEFAULT_MIRADORD_PATH)
 DEFAULT_COORD_PATH = os.path.join(
     os.path.dirname(__file__),
     "..",

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -27,7 +27,7 @@ POSTGRES_PASS = os.getenv("POSTGRES_PASS", "")
 POSTGRES_HOST = os.getenv("POSTGRES_HOST", "localhost")
 POSTGRES_IS_SETUP = POSTGRES_USER and POSTGRES_PASS and POSTGRES_HOST
 VERBOSE = os.getenv("VERBOSE", "0") == "1"
-LOG_LEVEL = os.getenv("LOG_LEVEL", "trace")
+LOG_LEVEL = os.getenv("LOG_LEVEL", "debug")
 assert LOG_LEVEL in ["trace", "debug", "info", "warn", "error"]
 DEFAULT_REV_PATH = os.path.join(
     os.path.dirname(__file__), "..", "..", "target/debug/revaultd"

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -59,6 +59,7 @@ DEFAULT_COSIG_PATH = os.path.join(
 COSIGNERD_PATH = os.getenv("COSIGNERD_PATH", DEFAULT_COSIG_PATH)
 DEFAULT_BITCOIND_PATH = "bitcoind"
 BITCOIND_PATH = os.getenv("BITCOIND_PATH", DEFAULT_BITCOIND_PATH)
+WT_PLUGINS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "wtplugins")
 
 
 def wait_for(success, timeout=TIMEOUT, debug_fn=None):

--- a/tests/test_framework/wtplugins/max_value_per_day.py
+++ b/tests/test_framework/wtplugins/max_value_per_day.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""A plugin which enforces a maximum total value per day.
+
+It needs as part of its config:
+    - A "data_dir" entry specifying where it is going to store its 'database'.
+    - A "max_value" entry specifying the maximum value per day to enforce.
+
+It simply stores a counter which is reset to 0 after 144 blocks (assumes no reorg).
+"""
+
+import json
+import os
+import sys
+
+
+DATASTORE_FNAME = "datastore.json"
+
+
+def read_request():
+    """Read a JSON request from stdin up to the '\n' delimiter."""
+    buf = ""
+    while len(buf) == 0 or buf[-1] != "\n":
+        buf += sys.stdin.read()
+    return json.loads(buf)
+
+
+def update_counter(config, counter):
+    data_store = os.path.join(config["data_dir"], DATASTORE_FNAME)
+    data = json.loads(open(data_store, "r").read())
+    data["counter"] = counter
+    open(data_store, "w+").write(json.dumps(data))
+
+
+def maybe_create_data_dir(config, block_height):
+    if not os.path.isdir(config["data_dir"]):
+        assert not os.path.exists(config["data_dir"])
+        os.makedirs(config["data_dir"])
+        data_store = os.path.join(config["data_dir"], DATASTORE_FNAME)
+        open(data_store, "w+").write(
+            json.dumps({"counter": 0, "block_height": block_height})
+        )
+
+
+def current_data(config):
+    with open(os.path.join(config["data_dir"], DATASTORE_FNAME), "r") as f:
+        return json.loads(f.read())
+
+
+if __name__ == "__main__":
+    req = read_request()
+    config = req["config"]
+    assert "data_dir" in config and "max_value" in config
+    block_info = req["block_info"]
+    maybe_create_data_dir(config, req["block_height"])
+    assert DATASTORE_FNAME in os.listdir(config["data_dir"])
+    data = current_data(config)
+
+    counter = data["counter"]
+    if req["block_height"] >= data["block_height"] + 144:
+        counter = 0
+
+    resp = {"revault": []}
+    for v in block_info["new_attempts"]:
+        if counter + v["value"] > config["max_value"]:
+            resp["revault"].append(v["deposit_outpoint"])
+            continue
+        counter += v["value"]
+    update_counter(config, counter)
+
+    sys.stdout.write(json.dumps(resp))
+    sys.stdout.flush()

--- a/tests/test_framework/wtplugins/revault_all.py
+++ b/tests/test_framework/wtplugins/revault_all.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""A plugin which returns any attempt sent to it as needing to be revaulted"""
+
+import json
+import sys
+
+
+def read_request():
+    """Read a JSON request from stdin up to the '\n' delimiter."""
+    buf = ""
+    while len(buf) == 0 or buf[-1] != "\n":
+        buf += sys.stdin.read()
+    return json.loads(buf)
+
+
+if __name__ == "__main__":
+    req = read_request()
+    block_info = req["block_info"]
+    resp = {"revault": [v["deposit_outpoint"] for v in block_info["new_attempts"]]}
+    sys.stdout.write(json.dumps(resp))
+    sys.stdout.flush()

--- a/tests/test_framework/wtplugins/revault_nothing.py
+++ b/tests/test_framework/wtplugins/revault_nothing.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""A plugin which never returns any attempt sent to it as needing to be revaulted"""
+
+import json
+import sys
+
+
+def read_request():
+    """Read a JSON request from stdin up to the '\n' delimiter."""
+    buf = ""
+    while len(buf) == 0 or buf[-1] != "\n":
+        buf += sys.stdin.read()
+    return json.loads(buf)
+
+
+if __name__ == "__main__":
+    req = read_request()
+    resp = {"revault": []}
+    sys.stdout.write(json.dumps(resp))
+    sys.stdout.flush()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -100,6 +100,7 @@ def test_revocation_sig_sharing(revault_network):
         wait_for(lambda: len(stk.rpc.listvaults(["secured"], [deposit])["vaults"]) > 0)
 
 
+@pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
 def test_raw_broadcast_cancel(revault_network, bitcoind):
     """
     Test broadcasting a dozen of pair of Unvault and Cancel for vaults with

--- a/tests/test_watchtowers.py
+++ b/tests/test_watchtowers.py
@@ -1,0 +1,25 @@
+import pytest
+
+from fixtures import *
+from test_framework.utils import (
+    POSTGRES_IS_SETUP,
+)
+
+
+@pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
+def test_wt_share_revocation_txs(revault_network, bitcoind):
+    """Sanity check that we share the Emergency signature with the watchtower
+    when we get all the revovation signatures for a vault.
+    """
+    rn = revault_network
+    rn.deploy(2, 1)
+    stk = rn.stk(0)
+
+    amount = 3.4444
+    v = rn.fund(amount)
+    deposit = f"{v['txid']}:{v['vout']}"
+    rn.secure_vault(v)
+    for stk in rn.stks():
+        stk.watchtower.wait_for_log(
+            f"Registered a new vault at '{deposit}'",
+        )

--- a/tests/test_watchtowers.py
+++ b/tests/test_watchtowers.py
@@ -8,9 +8,7 @@ from test_framework.utils import (
 
 @pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
 def test_wt_share_revocation_txs(revault_network, bitcoind):
-    """Sanity check that we share the Emergency signature with the watchtower
-    when we get all the revovation signatures for a vault.
-    """
+    """Sanity check that we share the revocation signatures with the watchtower."""
     rn = revault_network
     rn.deploy(2, 1)
     stk = rn.stk(0)
@@ -22,4 +20,14 @@ def test_wt_share_revocation_txs(revault_network, bitcoind):
     for stk in rn.stks():
         stk.watchtower.wait_for_log(
             f"Registered a new vault at '{deposit}'",
+        )
+
+    rn.activate_vault(v)
+    for stk in rn.stks():
+        stk.watchtower.wait_for_logs(
+            [
+                f"Got UnEmer transaction signatures for vault at '{deposit}'",
+                f"Got Cancel transaction signatures for vault at '{deposit}'."
+                " Now watching for Unvault broadcast.",
+            ]
         )

--- a/tests/test_watchtowers.py
+++ b/tests/test_watchtowers.py
@@ -1,8 +1,12 @@
+import os
 import pytest
 
+from bitcoin.core import COIN
 from fixtures import *
 from test_framework.utils import (
+    wait_for,
     POSTGRES_IS_SETUP,
+    WT_PLUGINS_DIR,
 )
 
 
@@ -31,3 +35,63 @@ def test_wt_share_revocation_txs(revault_network, bitcoind):
                 " Now watching for Unvault broadcast.",
             ]
         )
+
+
+@pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
+def test_wt_policy(directory, revault_network, bitcoind):
+    """Test we "can't" breach the policies defined by the watchtowers"""
+    rn = revault_network
+    CSV = 3
+    rn.deploy(2, 1, csv=CSV)
+    vaults = sorted(rn.fundmany([1, 2, 2, 4, 2, 2]), key=lambda v: v["amount"])
+    rn.activate_fresh_vaults(vaults)
+
+    # By default the watchtowers are configured with a plugin enforcing no
+    # spending policy.
+    rn.spend_vaults_anyhow([vaults[0]])
+
+    # If we have a single watchtower preventing any unvault, we won't be able
+    # to spend.
+    revault_all_path = os.path.join(WT_PLUGINS_DIR, "revault_all.py")
+    rn.stks()[0].watchtower.add_plugins([{"path": revault_all_path, "config": {}}])
+    rn.broadcast_unvaults_anyhow(vaults[1:3])
+    bitcoind.generate_block(1, 2)
+    rn.stks()[0].watchtower.wait_for_log("Broadcasted Cancel transaction")
+    for stk in rn.stks():
+        deposits = [f"{v['txid']}:{v['vout']}" for v in vaults[1:3]]
+        wait_for(
+            lambda: len(stk.rpc.listvaults(["canceling"], deposits)["vaults"]) == 2
+        )
+    bitcoind.generate_block(1)
+    rn.stks()[0].watchtower.remove_plugins([revault_all_path])
+
+    # Test a policy limiting the amount we can unvault per day
+    max_per_day_path = os.path.join(WT_PLUGINS_DIR, "max_value_per_day.py")
+    datadir = os.path.join(directory, "max_per_day_plugin_datadir")
+    plugin = {
+        "path": max_per_day_path,
+        "config": {"max_value": 5 * COIN, "data_dir": datadir},
+    }
+    rn.stks()[1].watchtower.add_plugins([plugin])
+    # The first one will go through (4 < 5)
+    v = vaults[-1]
+    assert v["amount"] == 4 * COIN
+    rn.spend_vaults_anyhow([v])
+    # The second one won't (4 + 2 > 5)
+    v = vaults[-2]
+    assert v["amount"] == 2 * COIN
+    assert len(bitcoind.rpc.getrawmempool()) == 0
+    rn.broadcast_unvaults_anyhow([v])
+    bitcoind.generate_block(1, 1)
+    rn.stks()[1].watchtower.wait_for_log("Broadcasted Cancel transaction")
+    for stk in rn.stks():
+        deposit = f"{v['txid']}:{v['vout']}"
+        wait_for(
+            lambda: len(stk.rpc.listvaults(["canceling"], [deposit])["vaults"]) == 1
+        )
+    bitcoind.generate_block(1)
+    # But it will if we wait till the next day, it'll go through
+    bitcoind.generate_block(144)
+    v = vaults[-3]
+    assert v["amount"] == 2 * COIN
+    rn.spend_vaults_anyhow([v])


### PR DESCRIPTION
This pull request, based on #306, implements the distribution of revocation signatures to the watchtower (https://github.com/revault/miradord).

The protocol defines a `sig` message per transaction and we leverage this on the watchtower to not allocate fee-bumping reserves before a vault is delegated. In order to do this we share the second-stage (ie the txs spending the Unvault) transactions signatures before sharing the Unvault to implicitly signal that we are about to share the Unvault transaction signature and the watchtower better be telling us not to do it now if it doesn't have sufficient reserve [0].
Of course, this is all simulation as we don't have fee-bumping reserve management implemented on the watchtower yet.
This translates here by having the background signature fetcher thread share the Emergency transaction signatures when it gathered them all (or to do it immediately in `revocationtxs` if we were passed them all at once).

This also adds a few plugins to test some basic spending policies (revault everything, revault nothing, revault according to a maximum per day). Note that by default we set the "revault nothing" policies as by default the watchtower would currently revault everything and this would break most of our tests :).

[0] I think we should not rely on this trick but instead modify the protocol. See https://github.com/revault/practical-revault/issues/109