### PR TITLE
Cache the connection in the signature fetcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ path = "src/bin/daemon.rs"
 name = "revault-cli"
 path = "src/bin/cli.rs"
 
+[features]
+bench = []
 
 [dependencies]
 revault_tx = { version = "0.4.0", features = ["use-serde"] }

--- a/src/daemon/control.rs
+++ b/src/daemon/control.rs
@@ -740,7 +740,7 @@ pub struct RpcUtils {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::daemon::{
         control::*,
         database::{
@@ -2424,5 +2424,77 @@ mod test {
             })
             .unwrap();
         cli_thread.join().unwrap();
+    }
+}
+
+#[cfg(all(test, feature = "bench"))]
+mod benches {
+    use super::*;
+
+    use revault_net::{
+        message, sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::gen_keypair,
+        transport::KKTransport,
+    };
+    use revault_tx::bitcoin::{
+        secp256k1, Network, PrivateKey as BitcoinPrivKey, PublicKey as BitcoinPubKey, Txid,
+    };
+
+    use std::{collections::BTreeMap, net::TcpListener, str::FromStr, thread};
+    use test::{black_box, Bencher};
+
+    fn create_keys(
+        ctx: &secp256k1::Secp256k1<secp256k1::All>,
+        secret_slice: &[u8],
+    ) -> (BitcoinPrivKey, BitcoinPubKey) {
+        let secret_key = secp256k1::SecretKey::from_slice(secret_slice).unwrap();
+        let private_key = BitcoinPrivKey {
+            compressed: true,
+            network: Network::Regtest,
+            key: secret_key,
+        };
+        let public_key = BitcoinPubKey::from_private_key(&ctx, &private_key);
+        (private_key, public_key)
+    }
+
+    // Benchmark the performance gain to not re-create the connection at each call
+    #[bench]
+    fn bench_presigs(bh: &mut Bencher) {
+        let ctx = secp256k1::Secp256k1::new();
+        let (_, public_key) = create_keys(&ctx, &[1; secp256k1::constants::SECRET_KEY_SIZE]);
+        let signature = secp256k1::Signature::from_str("304402201a3109a4a6445c1e56416bc39520aada5c8ad089e69ee4f1a40a0901de1a435302204b281ba97da2ab2e40eb65943ae414cc4307406c5eb177b1c646606839a2e99d").unwrap();
+        let mut sigs = BTreeMap::new();
+        sigs.insert(public_key.key, signature);
+        let other_sigs = sigs.clone();
+
+        let ((client_pubkey, client_privkey), (server_pubkey, server_privkey)) =
+            (gen_keypair(), gen_keypair());
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let txid =
+            Txid::from_str("cafa9f92be48ba41f9ee67e775b6c4afebd1bdbde5758792e9f30f6dea41e7fb")
+                .unwrap();
+
+        thread::spawn({
+            let id = txid;
+            move || loop {
+                let mut server_transport =
+                    KKTransport::accept(&listener, &server_privkey, &[client_pubkey])
+                        .expect("Server channel binding and accepting");
+                server_transport
+                    .read_req(|params| {
+                        assert_eq!(&params, &message::RequestParams::GetSigs(GetSigs { id }));
+                        Some(message::ResponseResult::Sigs(message::coordinator::Sigs {
+                            signatures: other_sigs.clone(),
+                        }))
+                    })
+                    .unwrap();
+            }
+        });
+
+        {
+            bh.iter(|| {
+                black_box(get_presigs(addr, &client_privkey, &server_pubkey, txid)).unwrap();
+            })
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(all(test, feature = "bench"), feature(test))]
+
+#[cfg(all(test, feature = "bench"))]
+extern crate test;
+
 pub mod common;
 pub mod daemon;
 


### PR DESCRIPTION
This fixes #310.

In case it was not already obvious this adds a benchmark for `get_presigs` demonstrating a >10x speedup.