### PR TITLE
panic hook: panic payload might be a String

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -144,17 +144,18 @@ pub fn setup_panic_hook() {
             .unwrap_or_else(|| "'unknown'".to_string());
 
         let bt = backtrace::Backtrace::new();
-        if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
-            log::error!(
-                "panic occurred at line {} of file {}: {:?}\n{:?}",
-                line,
-                file,
-                s,
-                bt
-            );
-        } else {
-            log::error!("panic occurred at line {} of file {}", line, file);
-        }
+        let info = panic_info
+            .payload()
+            .downcast_ref::<&str>()
+            .map(|s| s.to_string())
+            .or(panic_info.payload().downcast_ref::<String>().cloned());
+        log::error!(
+            "panic occurred at line {} of file {}: {:?}\n{:?}",
+            line,
+            file,
+            info,
+            bt
+        );
 
         process::exit(1);
     }));


### PR DESCRIPTION
The Rust documentation says that "[the PanicInfo payload] will
commonly, but not always, be a &'static str or String"