### PR TITLE
qa: mockable RPC commands for `bitcoind`

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -150,6 +150,7 @@ def revaultd_stakeholder(bitcoind, directory):
     coordinator_noise_key = (
         "d91563973102454a7830137e92d0548bc83b4ea2799f1df04622ca1307381402"
     )
+    bitcoind_cookie = os.path.join(bitcoind.bitcoin_dir, "regtest", ".cookie")
     revaultd = StakeholderRevaultd(
         datadir,
         dep_desc,
@@ -158,7 +159,8 @@ def revaultd_stakeholder(bitcoind, directory):
         os.urandom(32),
         coordinator_noise_key,
         reserve(),
-        bitcoind,
+        bitcoind.rpcport,
+        bitcoind_cookie,
         stk_config=stk_config,
         wt_process=None,
     )
@@ -194,6 +196,7 @@ def revaultd_manager(bitcoind, directory):
     coordinator_noise_key = (
         "d91563973102454a7830137e92d0548bc83b4ea2799f1df04622ca1307381402"
     )
+    bitcoind_cookie = os.path.join(bitcoind.bitcoin_dir, "regtest", ".cookie")
     revaultd = ManagerRevaultd(
         datadir,
         dep_desc,
@@ -202,7 +205,8 @@ def revaultd_manager(bitcoind, directory):
         os.urandom(32),
         coordinator_noise_key,
         reserve(),
-        bitcoind,
+        bitcoind.rpcport,
+        bitcoind_cookie,
         man_config=man_config,
     )
     revaultd.start()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
-python-bitcoinlib==0.11.0
 pytest==6.2
 pytest-xdist==1.31.0
 pytest-timeout==1.3.4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,7 @@ ephemeral_port_reserve==1.1.1
 bip32~=2.0
 psycopg2-binary==2.9
 pynacl==1.4
+
+# For the bitcoind proxy
+Flask==1.1.*
+cheroot==8.5.*

--- a/tests/test_framework/authproxy.py
+++ b/tests/test_framework/authproxy.py
@@ -1,0 +1,280 @@
+# This file was taken from the Bitcoin Core project in September 2021.
+# Copyright (c) 2021 The Bitcoin Core developers
+#
+# Copyright (c) 2011 Jeff Garzik
+#
+# Previous copyright, from python-jsonrpc/jsonrpc/proxy.py:
+#
+# Copyright (c) 2007 Jan-Klaas Kollhof
+#
+# This file is part of jsonrpc.
+#
+# jsonrpc is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this software; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+"""HTTP proxy for opening RPC connection to bitcoind.
+
+AuthServiceProxy has the following improvements over python-jsonrpc's
+ServiceProxy class:
+
+- HTTP connections persist for the life of the AuthServiceProxy object
+  (if server supports HTTP/1.1)
+- sends protocol 'version', per JSON-RPC 1.1
+- sends proper, incrementing 'id'
+- sends Basic HTTP authentication headers
+- parses all JSON numbers that look like floats as Decimal
+- uses standard Python json lib
+"""
+
+import base64
+import decimal
+from http import HTTPStatus
+import http.client
+import json
+import logging
+import os
+import socket
+import time
+import urllib.parse
+
+HTTP_TIMEOUT = 30
+USER_AGENT = "AuthServiceProxy/0.1"
+
+log = logging.getLogger("BitcoinRPC")
+
+
+class JSONRPCException(Exception):
+    def __init__(self, rpc_error, http_status=None):
+        try:
+            errmsg = "%(message)s (%(code)i)" % rpc_error
+        except (KeyError, TypeError):
+            errmsg = ""
+        super().__init__(errmsg)
+        self.error = rpc_error
+        self.http_status = http_status
+
+
+def EncodeDecimal(o):
+    if isinstance(o, decimal.Decimal):
+        return str(o)
+    raise TypeError(repr(o) + " is not JSON serializable")
+
+
+class AuthServiceProxy:
+    __id_count = 0
+
+    # ensure_ascii: escape unicode as \uXXXX, passed to json.dumps
+    def __init__(
+        self,
+        service_url,
+        service_name=None,
+        timeout=HTTP_TIMEOUT,
+        connection=None,
+        ensure_ascii=True,
+    ):
+        self.__service_url = service_url
+        self._service_name = service_name
+        self.ensure_ascii = ensure_ascii  # can be toggled on the fly by tests
+        self.__url = urllib.parse.urlparse(service_url)
+        user = (
+            b"" if self.__url.username is None else self.__url.username.encode("utf8")
+        )
+        passwd = (
+            b"" if self.__url.password is None else self.__url.password.encode("utf8")
+        )
+        authpair = user + b":" + passwd
+        self.__auth_header = b"Basic " + base64.b64encode(authpair)
+        self.timeout = timeout
+        self._set_conn(connection)
+
+    def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            # Python internal stuff
+            raise AttributeError
+        if self._service_name is not None:
+            name = "%s.%s" % (self._service_name, name)
+        return AuthServiceProxy(self.__service_url, name, connection=self.__conn)
+
+    def _request(self, method, path, postdata):
+        """
+        Do a HTTP request, with retry if we get disconnected (e.g. due to a timeout).
+        This is a workaround for https://bugs.python.org/issue3566 which is fixed in Python 3.5.
+        """
+        headers = {
+            "Host": self.__url.hostname,
+            "User-Agent": USER_AGENT,
+            "Authorization": self.__auth_header,
+            "Content-type": "application/json",
+        }
+        if os.name == "nt":
+            # Windows somehow does not like to re-use connections
+            # TODO: Find out why the connection would disconnect occasionally and make it reusable on Windows
+            # Avoid "ConnectionAbortedError: [WinError 10053] An established connection was aborted by the software in your host machine"
+            self._set_conn()
+        try:
+            self.__conn.request(method, path, postdata, headers)
+            return self._get_response()
+        except (BrokenPipeError, ConnectionResetError):
+            # Python 3.5+ raises BrokenPipeError when the connection was reset
+            # ConnectionResetError happens on FreeBSD
+            self.__conn.close()
+            self.__conn.request(method, path, postdata, headers)
+            return self._get_response()
+        except OSError as e:
+            retry = (
+                "[WinError 10053] An established connection was aborted by the software in your host machine"
+                in str(e)
+            )
+            # Workaround for a bug on macOS. See https://bugs.python.org/issue33450
+            retry = retry or ("[Errno 41] Protocol wrong type for socket" in str(e))
+            if retry:
+                self.__conn.close()
+                self.__conn.request(method, path, postdata, headers)
+                return self._get_response()
+            else:
+                raise
+
+    def get_request(self, *args, **argsn):
+        AuthServiceProxy.__id_count += 1
+
+        log.debug(
+            "-{}-> {} {}".format(
+                AuthServiceProxy.__id_count,
+                self._service_name,
+                json.dumps(
+                    args or argsn, default=EncodeDecimal, ensure_ascii=self.ensure_ascii
+                ),
+            )
+        )
+        if args and argsn:
+            raise ValueError("Cannot handle both named and positional arguments")
+        return {
+            "version": "1.1",
+            "method": self._service_name,
+            "params": args or argsn,
+            "id": AuthServiceProxy.__id_count,
+        }
+
+    def __call__(self, *args, **argsn):
+        postdata = json.dumps(
+            self.get_request(*args, **argsn),
+            default=EncodeDecimal,
+            ensure_ascii=self.ensure_ascii,
+        )
+        response, status = self._request(
+            "POST", self.__url.path, postdata.encode("utf-8")
+        )
+        if response["error"] is not None:
+            raise JSONRPCException(response["error"], status)
+        elif "result" not in response:
+            raise JSONRPCException(
+                {"code": -343, "message": "missing JSON-RPC result"}, status
+            )
+        elif status != HTTPStatus.OK:
+            raise JSONRPCException(
+                {
+                    "code": -342,
+                    "message": "non-200 HTTP status code but no JSON-RPC error",
+                },
+                status,
+            )
+        else:
+            return response["result"]
+
+    def batch(self, rpc_call_list):
+        postdata = json.dumps(
+            list(rpc_call_list), default=EncodeDecimal, ensure_ascii=self.ensure_ascii
+        )
+        log.debug("--> " + postdata)
+        response, status = self._request(
+            "POST", self.__url.path, postdata.encode("utf-8")
+        )
+        if status != HTTPStatus.OK:
+            raise JSONRPCException(
+                {
+                    "code": -342,
+                    "message": "non-200 HTTP status code but no JSON-RPC error",
+                },
+                status,
+            )
+        return response
+
+    def _get_response(self):
+        req_start_time = time.time()
+        try:
+            http_response = self.__conn.getresponse()
+        except socket.timeout:
+            raise JSONRPCException(
+                {
+                    "code": -344,
+                    "message": "%r RPC took longer than %f seconds. Consider "
+                    "using larger timeout for calls that take "
+                    "longer to return." % (self._service_name, self.__conn.timeout),
+                }
+            )
+        if http_response is None:
+            raise JSONRPCException(
+                {"code": -342, "message": "missing HTTP response from server"}
+            )
+
+        content_type = http_response.getheader("Content-Type")
+        if content_type != "application/json":
+            raise JSONRPCException(
+                {
+                    "code": -342,
+                    "message": "non-JSON HTTP response with '%i %s' from server"
+                    % (http_response.status, http_response.reason),
+                },
+                http_response.status,
+            )
+
+        responsedata = http_response.read().decode("utf8")
+        response = json.loads(responsedata, parse_float=decimal.Decimal)
+        elapsed = time.time() - req_start_time
+        if "error" in response and response["error"] is None:
+            log.debug(
+                "<-%s- [%.6f] %s"
+                % (
+                    response["id"],
+                    elapsed,
+                    json.dumps(
+                        response["result"],
+                        default=EncodeDecimal,
+                        ensure_ascii=self.ensure_ascii,
+                    ),
+                )
+            )
+        else:
+            log.debug("<-- [%.6f] %s" % (elapsed, responsedata))
+        return response, http_response.status
+
+    def __truediv__(self, relative_uri):
+        return AuthServiceProxy(
+            "{}/{}".format(self.__service_url, relative_uri),
+            self._service_name,
+            connection=self.__conn,
+        )
+
+    def _set_conn(self, connection=None):
+        port = 80 if self.__url.port is None else self.__url.port
+        if connection:
+            self.__conn = connection
+            self.timeout = connection.timeout
+        elif self.__url.scheme == "https":
+            self.__conn = http.client.HTTPSConnection(
+                self.__url.hostname, port, timeout=self.timeout
+            )
+        else:
+            self.__conn = http.client.HTTPConnection(
+                self.__url.hostname, port, timeout=self.timeout
+            )

--- a/tests/test_framework/authproxy.py
+++ b/tests/test_framework/authproxy.py
@@ -147,15 +147,16 @@ class AuthServiceProxy:
     def get_request(self, *args, **argsn):
         AuthServiceProxy.__id_count += 1
 
-        log.debug(
-            "-{}-> {} {}".format(
-                AuthServiceProxy.__id_count,
-                self._service_name,
-                json.dumps(
-                    args or argsn, default=EncodeDecimal, ensure_ascii=self.ensure_ascii
-                ),
-            )
-        )
+        # FIXME: keep this but with a lower degree of verbosity
+        # log.debug(
+        # "-{}-> {} {}".format(
+        # AuthServiceProxy.__id_count,
+        # self._service_name,
+        # json.dumps(
+        # args or argsn, default=EncodeDecimal, ensure_ascii=self.ensure_ascii
+        # ),
+        # )
+        # )
         if args and argsn:
             raise ValueError("Cannot handle both named and positional arguments")
         return {
@@ -195,7 +196,8 @@ class AuthServiceProxy:
         postdata = json.dumps(
             list(rpc_call_list), default=EncodeDecimal, ensure_ascii=self.ensure_ascii
         )
-        log.debug("--> " + postdata)
+        # FIXME: keep this but with a lower degree of verbosity
+        # log.debug("--> " + postdata)
         response, status = self._request(
             "POST", self.__url.path, postdata.encode("utf-8")
         )
@@ -210,7 +212,7 @@ class AuthServiceProxy:
         return response
 
     def _get_response(self):
-        req_start_time = time.time()
+        # req_start_time = time.time()
         try:
             http_response = self.__conn.getresponse()
         except socket.timeout:
@@ -240,22 +242,23 @@ class AuthServiceProxy:
 
         responsedata = http_response.read().decode("utf8")
         response = json.loads(responsedata, parse_float=decimal.Decimal)
-        elapsed = time.time() - req_start_time
-        if "error" in response and response["error"] is None:
-            log.debug(
-                "<-%s- [%.6f] %s"
-                % (
-                    response["id"],
-                    elapsed,
-                    json.dumps(
-                        response["result"],
-                        default=EncodeDecimal,
-                        ensure_ascii=self.ensure_ascii,
-                    ),
-                )
-            )
-        else:
-            log.debug("<-- [%.6f] %s" % (elapsed, responsedata))
+        # FIXME: keep this but with a lower degree of verbosity
+        # elapsed = time.time() - req_start_time
+        # if "error" in response and response["error"] is None:
+        # log.debug(
+        # "<-%s- [%.6f] %s"
+        # % (
+        # response["id"],
+        # elapsed,
+        # json.dumps(
+        # response["result"],
+        # default=EncodeDecimal,
+        # ensure_ascii=self.ensure_ascii,
+        # ),
+        # )
+        # )
+        # else:
+        # log.debug("<-- [%.6f] %s" % (elapsed, responsedata))
         return response, http_response.status
 
     def __truediv__(self, relative_uri):

--- a/tests/test_framework/bitcoind.py
+++ b/tests/test_framework/bitcoind.py
@@ -1,13 +1,18 @@
+import decimal
+import json
 import logging
 import os
+import threading
 
+from cheroot.wsgi import PathInfoDispatcher, Server
 from decimal import Decimal
 from ephemeral_port_reserve import reserve
-from test_framework.authproxy import AuthServiceProxy
+from flask import Flask, request, Response
+from test_framework.authproxy import AuthServiceProxy, JSONRPCException
 from test_framework.utils import TailableProc, wait_for, TIMEOUT, BITCOIND_PATH, COIN
 
 
-class BitcoinDProxy:
+class BitcoindRpcInterface:
     def __init__(self, data_dir, network, rpc_port):
         self.cookie_path = os.path.join(data_dir, network, ".cookie")
         self.rpc_port = rpc_port
@@ -68,7 +73,7 @@ class BitcoinD(TailableProc):
             for k, v in bitcoind_conf.items():
                 f.write(f"{k}={v}\n")
 
-        self.rpc = BitcoinDProxy(bitcoin_dir, "regtest", rpcport)
+        self.rpc = BitcoindRpcInterface(bitcoin_dir, "regtest", rpcport)
 
     def start(self):
         TailableProc.start(self)
@@ -186,3 +191,105 @@ class BitcoinD(TailableProc):
         except Exception:
             self.proc.kill()
         self.proc.wait()
+
+
+class DecimalEncoder(json.JSONEncoder):
+    """By default json.dumps does not handle Decimals correctly, so we override its handling"""
+
+    def default(self, o):
+        if isinstance(o, decimal.Decimal):
+            return float(o)
+        return super(DecimalEncoder, self).default(o)
+
+
+class BitcoindRpcProxy(object):
+    """A proxy to the bitcoind RPC interface that can replace commands with arbitrary results.
+
+    Starts a HTTP server in a thread, listens for incoming JSONRPC requests, and responds with
+    either a mocked result or the result it got from bitcoind.
+    This was taken and adapted from the C-lightning test suite.
+    """
+
+    def __init__(self, bitcoind_rpc_port, bitcoind_cookie_path, mocks):
+        self.app = Flask("BitcoindProxy")
+        self.app.add_url_rule(
+            "/",
+            "Entrypoint",
+            self.proxy,
+            methods=["POST"],
+            defaults={"path": ""},
+        )
+        self.app.add_url_rule(
+            "/<path:path>",
+            "Entrypoint",
+            self.proxy,
+            methods=["POST"],
+        )
+        self.rpcport = reserve()
+        # A mapping from method name to result as a dict.
+        # Eventually, the results could be callable.
+        self.mocks = mocks
+        self.bitcoind_rpc_port = bitcoind_rpc_port
+        self.bitcoind_cookie_path = bitcoind_cookie_path
+
+        self.start()
+
+    def __del__(self):
+        self.stop()
+
+    def _handle_request(self, r, path):
+        """Handle a JSONRPC request {r} made to the HTTP endpoint {path} (to handle
+        wallet paths)"""
+        method = r["method"]
+
+        # If we have set a mock for this method reply with that
+        if method in self.mocks:
+            return {"id": r["id"], "error": None, "result": self.mocks[method]}
+
+        # Otherwise, just forward the request
+        with open(self.bitcoind_cookie_path) as fd:
+            authpair = fd.read()
+        service_url = f"http://{authpair}@localhost:{self.bitcoind_rpc_port}/{path}"
+
+        try:
+            res = AuthServiceProxy(service_url, r["method"])(*r["params"])
+            return {"result": res, "id": r["id"]}
+        except JSONRPCException as e:
+            return {"error": e.error, "id": r["id"]}
+
+    def proxy(self, path):
+        r = json.loads(request.data.decode("ASCII"))
+
+        if isinstance(r, list):
+            reply = [self._handle_request(subreq, path) for subreq in r]
+        else:
+            reply = self._handle_request(r, path)
+
+        # \r\n because rust-jsonrpc expects it..
+        response = Response(json.dumps(reply, cls=DecimalEncoder) + "\r\n")
+        response.headers["Content-Type"] = "application/json"
+        return response
+
+    def start(self):
+        self.server = Server(
+            ("127.0.0.1", self.rpcport),
+            self.app,
+            numthreads=32,
+            request_queue_size=10,
+            accepted_queue_timeout=20,
+            timeout=TIMEOUT * 2,
+        )
+        self.proxy_thread = threading.Thread(target=self.server.start)
+        self.proxy_thread.daemon = True
+        self.proxy_thread.start()
+
+        # Now that bitcoind is running on the real rpcport, let's tell all
+        # future callers to talk to the proxyport. We use the bind_addr as a
+        # signal that the port is bound and accepting connections.
+        while self.server.bind_addr[1] == 0:
+            pass
+        self.rpcport = self.server.bind_addr[1]
+
+    def stop(self):
+        self.server.stop()
+        self.proxy_thread.join()

--- a/tests/test_framework/bitcoind.py
+++ b/tests/test_framework/bitcoind.py
@@ -199,12 +199,11 @@ class BitcoinD(TailableProc):
             raise
 
         info = self.rpc.getnetworkinfo()
-
-        if info["version"] < 210000:
+        if info["version"] < 220000:
             self.rpc.stop()
             raise ValueError(
-                "bitcoind is too old. At least version 21000"
-                " (v0.21.0) is needed, current version is {}".format(info["version"])
+                "bitcoind is too old. Minimum supported version is 0.22.0."
+                " Current is {}".format(info["version"])
             )
 
     def cleanup(self):

--- a/tests/test_framework/bitcoind.py
+++ b/tests/test_framework/bitcoind.py
@@ -1,11 +1,10 @@
-import bitcoin
 import logging
 import os
 
 from decimal import Decimal
 from ephemeral_port_reserve import reserve
 from test_framework.authproxy import AuthServiceProxy
-from test_framework.utils import TailableProc, wait_for, TIMEOUT, BITCOIND_PATH
+from test_framework.utils import TailableProc, wait_for, TIMEOUT, BITCOIND_PATH, COIN
 
 
 class BitcoinDProxy:
@@ -59,7 +58,7 @@ class BitcoinD(TailableProc):
             "port": self.p2pport,
             "rpcport": rpcport,
             "debug": 1,
-            "fallbackfee": Decimal(1000) / bitcoin.core.COIN,
+            "fallbackfee": Decimal(1000) / COIN,
             "rpcthreads": 32,
         }
         self.conf_file = os.path.join(bitcoin_dir, "bitcoin.conf")

--- a/tests/test_framework/miradord.py
+++ b/tests/test_framework/miradord.py
@@ -27,7 +27,8 @@ class Miradord(TailableProc):
         stk_noise_key,
         coordinator_noise_key,
         coordinator_port,
-        bitcoind,
+        bitcoind_rpcport,
+        bitcoind_cookie,
         plugins=[],
     ):
         """All public keys must be hex"""
@@ -40,7 +41,6 @@ class Miradord(TailableProc):
         self.unvault_desc = unvault_desc
         self.cpfp_desc = cpfp_desc
         self.emer_addr = emer_addr
-        self.bitcoind = bitcoind
 
         # The data is stored in a per-network directory. We need to create it
         # in order to write the Noise private key
@@ -58,7 +58,6 @@ class Miradord(TailableProc):
             f"Watchtower Noise key: {wt_noise_key.hex()}, Stakeholder Noise key: {stk_noise_key}"
         )
 
-        bitcoind_cookie = os.path.join(bitcoind.bitcoin_dir, "regtest", ".cookie")
         with open(self.conf_file, "w") as f:
             f.write(f"data_dir = '{datadir}'\n")
             f.write("daemon = false\n")
@@ -81,7 +80,7 @@ class Miradord(TailableProc):
             f.write("[bitcoind_config]\n")
             f.write('network = "regtest"\n')
             f.write(f"cookie_path = '{bitcoind_cookie}'\n")
-            f.write(f"addr = '127.0.0.1:{bitcoind.rpcport}'\n")
+            f.write(f"addr = '127.0.0.1:{bitcoind_rpcport}'\n")
             f.write("poll_interval_secs = 5\n")
 
             f.write(f"\n{toml.dumps({'plugins': plugins})}\n")

--- a/tests/test_framework/revault_network.py
+++ b/tests/test_framework/revault_network.py
@@ -1,10 +1,8 @@
 import bip32
-import bitcoin
 import logging
 import os
 import random
 
-from bitcoin.wallet import CBitcoinSecret
 from ephemeral_port_reserve import reserve
 from nacl.public import PrivateKey as Curve25519Private
 from test_framework import serializations
@@ -16,7 +14,6 @@ from test_framework.utils import (
     get_descriptors,
     get_participants,
     wait_for,
-    RpcError,
     TIMEOUT,
     WT_PLUGINS_DIR,
 )
@@ -104,10 +101,8 @@ class RevaultNetwork:
             stks_xpubs, cosigs_keys, mans_xpubs, managers_threshold, cpfp_xpubs, csv
         )
         # Generate a dummy 2of2 to be used as our Emergency address
-        bitcoin.SelectParams("regtest")
-        pka = str(CBitcoinSecret.from_secret_bytes(os.urandom(32)))
-        pkb = str(CBitcoinSecret.from_secret_bytes(os.urandom(32)))
-        desc = f"wsh(multi(2,{pka},{pkb}))"
+        desc = "wsh(multi(2,cRE7qAArQYnFQK7S1gXFTArFT4UWvh8J2v2EUajRWXbWFvRzxoeF,\
+                cTzcgRCmHNqUqZuZgvCPLUDXXrQSoVQpZiXQZWQzsLEytcTr6iXi))"
         checksum = self.bitcoind.rpc.getdescriptorinfo(desc)["checksum"]
         desc = f"{desc}#{checksum}"
         self.emergency_address = self.bitcoind.rpc.deriveaddresses(desc)[0]

--- a/tests/test_framework/revaultd.py
+++ b/tests/test_framework/revaultd.py
@@ -21,7 +21,8 @@ class Revaultd(TailableProc):
         noise_priv,
         coordinator_noise_key,
         coordinator_port,
-        bitcoind,
+        bitcoind_rpc_port,
+        bitcoind_cookie_path,
         stk_config=None,
         man_config=None,
         wt_process=None,
@@ -51,7 +52,6 @@ class Revaultd(TailableProc):
         with open(noise_secret_file, "wb") as f:
             f.write(noise_priv)
 
-        bitcoind_cookie = os.path.join(bitcoind.bitcoin_dir, "regtest", ".cookie")
         with open(self.conf_file, "w") as f:
             f.write(f"data_dir = '{datadir}'\n")
             f.write("daemon = false\n")
@@ -68,8 +68,8 @@ class Revaultd(TailableProc):
 
             f.write("[bitcoind_config]\n")
             f.write('network = "regtest"\n')
-            f.write(f"cookie_path = '{bitcoind_cookie}'\n")
-            f.write(f"addr = '127.0.0.1:{bitcoind.rpcport}'\n")
+            f.write(f"cookie_path = '{bitcoind_cookie_path}'\n")
+            f.write(f"addr = '127.0.0.1:{bitcoind_rpc_port}'\n")
             f.write("poll_interval_secs = 10\n")
 
             if stk_config is not None:
@@ -167,7 +167,8 @@ class ManagerRevaultd(Revaultd):
         noise_priv,
         coordinator_noise_key,
         coordinator_port,
-        bitcoind,
+        bitcoind_rpc,
+        bitcoind_cookie,
         man_config,
     ):
         """The wallet daemon for a manager.
@@ -182,7 +183,8 @@ class ManagerRevaultd(Revaultd):
             noise_priv,
             coordinator_noise_key,
             coordinator_port,
-            bitcoind,
+            bitcoind_rpc,
+            bitcoind_cookie,
             man_config=man_config,
         )
         assert self.man_keychain is not None
@@ -198,7 +200,8 @@ class StakeholderRevaultd(Revaultd):
         noise_priv,
         coordinator_noise_key,
         coordinator_port,
-        bitcoind,
+        bitcoind_rpc,
+        bitcoind_cookie,
         stk_config,
         wt_process,
     ):
@@ -214,7 +217,8 @@ class StakeholderRevaultd(Revaultd):
             noise_priv,
             coordinator_noise_key,
             coordinator_port,
-            bitcoind,
+            bitcoind_rpc,
+            bitcoind_cookie,
             stk_config,
             man_config=None,
             wt_process=wt_process,
@@ -232,7 +236,8 @@ class StkManRevaultd(Revaultd):
         noise_priv,
         coordinator_noise_key,
         coordinator_port,
-        bitcoind,
+        bitcoind_rpc,
+        bitcoind_cookie,
         stk_config,
         man_config,
         wt_process,
@@ -246,7 +251,8 @@ class StkManRevaultd(Revaultd):
             noise_priv,
             coordinator_noise_key,
             coordinator_port,
-            bitcoind,
+            bitcoind_rpc,
+            bitcoind_cookie,
             stk_config,
             man_config,
             wt_process,

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -62,6 +62,9 @@ BITCOIND_PATH = os.getenv("BITCOIND_PATH", DEFAULT_BITCOIND_PATH)
 WT_PLUGINS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "wtplugins")
 
 
+COIN = 10 ** 8
+
+
 def wait_for(success, timeout=TIMEOUT, debug_fn=None):
     """
     Run success() either until it returns True, or until the timeout is reached.

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,13 +2,13 @@ import logging
 import pytest
 import os
 
-from bitcoin.core import COIN
 from fixtures import *
 from test_framework.utils import (
     TailableProc,
     POSTGRES_IS_SETUP,
     RpcError,
     wait_for,
+    COIN,
 )
 
 

--- a/tests/test_watchtowers.py
+++ b/tests/test_watchtowers.py
@@ -1,12 +1,12 @@
 import os
 import pytest
 
-from bitcoin.core import COIN
 from fixtures import *
 from test_framework.utils import (
     wait_for,
     POSTGRES_IS_SETUP,
     WT_PLUGINS_DIR,
+    COIN,
 )
 
 


### PR DESCRIPTION
It's really helpful to have a mockable interface between the daemons and the `bitcoind` they query.
This is particularly helpful to test the error handling code for robustness by simulating some spurious failures on the `bitcoind` backend.
It also comes handy in cases like for #302 where we'd like to customize the fee estimation returned by `bitcoind` in order to test different CPFP scenarii.

This adds an optional proxy between the `revaultd`, `miradord` and their `bitcoind`. We use it to either pass through or mock commands.

Based on #323, since, well, it fixed the CI.