### PR TITLE
qa: remove a spurious remaining occurence of python-bitcoinlib

### DIFF
--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -7,10 +7,10 @@ etc..
 import pytest
 import random
 
-from bitcoin.core import COIN
 from fixtures import *
 from test_framework import serializations
 from test_framework.utils import (
+    COIN,
     POSTGRES_IS_SETUP,
     RpcError,
     wait_for,


### PR DESCRIPTION
Makes the CI fails on Spend tests.