### PR TITLE
Fix Cargo clippy

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -112,7 +112,7 @@ fn trimmed(mut vec: Vec<u8>, bytes_read: usize) -> Vec<u8> {
     // Until there is some whatever-newline character, pop.
     while let Some(byte) = vec.last() {
         // Of course, we assume utf-8
-        if byte < &0x0a || byte > &0x0d {
+        if !(&0x0a..=&0x0d).contains(&byte) {
             break;
         }
         vec.pop();
@@ -160,18 +160,16 @@ fn main() {
                 if response.get("id") == request.get("id") {
                     if raw {
                         print!("{}", response);
+                    } else if let Some(r) = response.get("result") {
+                        println!("{:#}", serde_json::json!({ "result": r }));
+                    } else if let Some(e) = response.get("error") {
+                        println!("{:#}", serde_json::json!({ "error": e }));
                     } else {
-                        if let Some(r) = response.get("result") {
-                            println!("{:#}", serde_json::json!({ "result": r }));
-                        } else if let Some(e) = response.get("error") {
-                            println!("{:#}", serde_json::json!({ "error": e }));
-                        } else {
-                            log::warn!(
-                                "revaultd response doesn't contain result or error: '{}'",
-                                response
-                            );
-                            println!("{:#}", response);
-                        }
+                        log::warn!(
+                            "revaultd response doesn't contain result or error: '{}'",
+                            response
+                        );
+                        println!("{:#}", response);
                     }
                     return;
                 }

--- a/src/daemon/bitcoind/mod.rs
+++ b/src/daemon/bitcoind/mod.rs
@@ -116,7 +116,7 @@ fn bitcoind_sanity_checks(
     bitcoind: &BitcoinD,
     bitcoind_config: &BitcoindConfig,
 ) -> Result<(), BitcoindError> {
-    check_bitcoind_network(&bitcoind, &bitcoind_config.network)
+    check_bitcoind_network(bitcoind, &bitcoind_config.network)
 }
 
 /// Connects to and sanity checks bitcoind.
@@ -177,11 +177,10 @@ pub fn bitcoind_main_loop(
 
     // We use a thread to 1) wait for bitcoind to be synced 2) poll listunspent
     let poller_thread = std::thread::spawn({
-        let _revaultd = revaultd.clone();
         let _bitcoind = bitcoind.clone();
         let _sync_progress = sync_progress.clone();
         let _shutdown = shutdown.clone();
-        move || poller_main(_revaultd, _bitcoind, _sync_progress, _shutdown)
+        move || poller_main(revaultd, _bitcoind, _sync_progress, _shutdown)
     });
 
     for msg in rx {

--- a/src/daemon/bitcoind/utils.rs
+++ b/src/daemon/bitcoind/utils.rs
@@ -146,11 +146,11 @@ pub fn unvault_txin_from_deposit(
 ) -> Result<UnvaultTxIn, BitcoindError> {
     let revaultd = revaultd.read().unwrap();
     let db_path = revaultd.db_file();
-    let db_vault = db_vault_by_deposit(&db_path, &deposit_outpoint)?
+    let db_vault = db_vault_by_deposit(&db_path, deposit_outpoint)?
         .expect("Checking Unvault txid for an unknow deposit");
     let unvault_descriptor = revaultd.derived_unvault_descriptor(db_vault.derivation_index);
 
-    let unvault_tx = if let Some(tx) = db_unvault_from_deposit(&db_path, &deposit_outpoint)? {
+    let unvault_tx = if let Some(tx) = db_unvault_from_deposit(&db_path, deposit_outpoint)? {
         tx
     } else {
         let deposit_descriptor = revaultd.derived_deposit_descriptor(db_vault.derivation_index);

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -84,7 +84,7 @@ fn create_db(revaultd: &RevaultD) -> Result<(), DatabaseError> {
         .map_err(|e| DatabaseError(format!("Creating db file: {}", e.to_string())))?;
 
     db_exec(&db_path, |tx| {
-        tx.execute_batch(&SCHEMA)
+        tx.execute_batch(SCHEMA)
             .map_err(|e| DatabaseError(format!("Creating database: {}", e.to_string())))?;
         tx.execute(
             "INSERT INTO version (version) VALUES (?1)",
@@ -205,10 +205,10 @@ pub fn setup_db(revaultd: &mut RevaultD) -> Result<(), DatabaseError> {
     let db_path = revaultd.db_file();
     if !db_path.exists() {
         log::info!("No database at {:?}, creating a new one.", db_path);
-        create_db(&revaultd)?;
+        create_db(revaultd)?;
     }
 
-    check_db(&revaultd)?;
+    check_db(revaultd)?;
     state_from_db(revaultd)?;
 
     Ok(())
@@ -307,6 +307,7 @@ macro_rules! db_store_unsigned_transactions {
 /// Mark an unconfirmed deposit as being in 'Funded' state (confirmed), as well as storing the
 /// unsigned "presigned-transactions".
 /// The `emer_tx` and `unemer_tx` may only be passed for stakeholders.
+#[allow(clippy::too_many_arguments)]
 pub fn db_confirm_deposit(
     db_path: &Path,
     outpoint: &OutPoint,
@@ -574,7 +575,7 @@ pub fn db_mark_spent_unvault(
     vault_id: u32,
     blocktime: u32,
 ) -> Result<(), DatabaseError> {
-    db_mark_vault_as_moved(&db_path, vault_id, VaultStatus::Spent, blocktime)
+    db_mark_vault_as_moved(db_path, vault_id, VaultStatus::Spent, blocktime)
 }
 
 /// Update vault status to `canceled` and set moved_at with given blocktime.
@@ -583,7 +584,7 @@ pub fn db_mark_canceled_unvault(
     vault_id: u32,
     blocktime: u32,
 ) -> Result<(), DatabaseError> {
-    db_mark_vault_as_moved(&db_path, vault_id, VaultStatus::Canceled, blocktime)
+    db_mark_vault_as_moved(db_path, vault_id, VaultStatus::Canceled, blocktime)
 }
 
 /// Update vault status to `emergencied` and set moved_at with given blocktime.
@@ -593,7 +594,7 @@ pub fn db_mark_emergencied_unvault(
     blocktime: u32,
 ) -> Result<(), DatabaseError> {
     db_mark_vault_as_moved(
-        &db_path,
+        db_path,
         vault_id,
         VaultStatus::UnvaultEmergencyVaulted,
         blocktime,
@@ -617,7 +618,7 @@ pub fn db_mark_emergencied_vault(
     vault_id: u32,
     blocktime: u32,
 ) -> Result<(), DatabaseError> {
-    db_mark_vault_as_moved(&db_path, vault_id, VaultStatus::EmergencyVaulted, blocktime)
+    db_mark_vault_as_moved(db_path, vault_id, VaultStatus::EmergencyVaulted, blocktime)
 }
 
 /// Mark that we actually signed this vault's revocation txs, and stored the signatures for it.
@@ -824,7 +825,7 @@ pub fn db_insert_spend(
         )?;
         let spend_id = db_tx.last_insert_rowid();
 
-        for unvault_tx in unvault_txs.into_iter() {
+        for unvault_tx in unvault_txs {
             db_tx.execute(
                 "INSERT INTO spend_inputs (unvault_id, spend_id) VALUES (?1, ?2)",
                 params![unvault_tx.id, spend_id],

--- a/src/daemon/database/interface.rs
+++ b/src/daemon/database/interface.rs
@@ -57,12 +57,7 @@ where
 }
 
 // Internal helper for queries boilerplate
-fn db_query<'a, P, F, T>(
-    path: &Path,
-    stmt_str: &'a str,
-    params: P,
-    f: F,
-) -> Result<Vec<T>, DatabaseError>
+fn db_query<P, F, T>(path: &Path, stmt_str: &str, params: P, f: F) -> Result<Vec<T>, DatabaseError>
 where
     P: IntoIterator + rusqlite::Params,
     P::Item: ToSql,
@@ -176,20 +171,14 @@ pub fn db_wallet(db_path: &Path) -> Result<DbWallet, DatabaseError> {
 
         let our_man_xpub_str = row.get::<_, Option<String>>(5)?;
         let our_man_xpub = if let Some(ref xpub_str) = our_man_xpub_str {
-            Some(
-                ExtendedPubKey::from_str(&xpub_str)
-                    .map_err(|e| FromSqlError::Other(Box::new(e)))?,
-            )
+            Some(ExtendedPubKey::from_str(xpub_str).map_err(|e| FromSqlError::Other(Box::new(e)))?)
         } else {
             None
         };
 
         let our_stk_xpub_str = row.get::<_, Option<String>>(6)?;
         let our_stk_xpub = if let Some(ref xpub_str) = our_stk_xpub_str {
-            Some(
-                ExtendedPubKey::from_str(&xpub_str)
-                    .map_err(|e| FromSqlError::Other(Box::new(e)))?,
-            )
+            Some(ExtendedPubKey::from_str(xpub_str).map_err(|e| FromSqlError::Other(Box::new(e)))?)
         } else {
             None
         };

--- a/src/daemon/jsonrpc/server.rs
+++ b/src/daemon/jsonrpc/server.rs
@@ -37,7 +37,7 @@ fn trimmed(mut vec: Vec<u8>, bytes_read: usize) -> Vec<u8> {
     // Until there is some whatever-newline character, pop.
     while let Some(byte) = vec.last() {
         // Of course, we assume utf-8
-        if byte < &0x0a || byte > &0x0d {
+        if !(&0x0a..=&0x0d).contains(&byte) {
             break;
         }
         vec.pop();

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -148,7 +148,7 @@ pub fn setup_panic_hook() {
             .payload()
             .downcast_ref::<&str>()
             .map(|s| s.to_string())
-            .or(panic_info.payload().downcast_ref::<String>().cloned());
+            .or_else(|| panic_info.payload().downcast_ref::<String>().cloned());
         log::error!(
             "panic occurred at line {} of file {}: {:?}\n{:?}",
             line,

--- a/src/daemon/sigfetcher.rs
+++ b/src/daemon/sigfetcher.rs
@@ -171,7 +171,7 @@ fn maybe_wt_share_signatures(
         );
         wts_share_emer_signatures(
             &revaultd.noise_secret,
-            &watchtowers,
+            watchtowers,
             db_vault.deposit_outpoint,
             db_vault.derivation_index,
             &emer_tx,
@@ -227,7 +227,7 @@ fn fetch_all_signatures(
             continue;
         }
         // Check if we can share the Emer signature with the watchtowers
-        if let Err(e) = maybe_wt_share_signatures(revaultd, &db_path, &db_vault) {
+        if let Err(e) = maybe_wt_share_signatures(revaultd, db_path, &db_vault) {
             log::error!(
                 "Error sharing emergency signatures with watchtowers: '{}'",
                 e

--- a/src/daemon/threadmessages.rs
+++ b/src/daemon/threadmessages.rs
@@ -53,7 +53,7 @@ impl<'a> BitcoindThread for BitcoindSender {
             self.0
                 .send(BitcoindMessageOut::BroadcastTransactions(
                     transactions,
-                    bitrep_tx.clone(),
+                    bitrep_tx,
                 ))
                 .expect("Sending to bitcoind thread");
             bitrep_rx.recv().expect("Receiving from bitcoind thread")?;


### PR DESCRIPTION
This commit doesn't fix all the cargo clippy warnings, but drastically
reduces them (from 107 warnings to 11).
Some of the most popular warnings:
- https://rust-lang.github.io/rust-clippy/master/#redundant_clone
- https://rust-lang.github.io/rust-clippy/master/#needless_borrow
- https://rust-lang.github.io/rust-clippy/master/#redundant_closure