### PR TITLE
commands: a second API for `revaultd`

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -174,9 +174,9 @@ of the vaults is unknown or not at least `funded`.
 The output PSBTs may be unsigned, partially signed, or finalized (depending on each
 vault's state).
 
-| Parameter   | Type         | Description                                                                                     |
-| ----------- | ------------ | ----------------------------------------------------------------------------------------------- |
-| `outpoints` | string array | Vault IDs -- optional, filter the list with the given vault Outpoints                           |
+| Parameter   | Type         | Description                                                                                                 |
+| ----------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
+| `outpoints` | string array | Vault IDs -- optional, filter the list with the given vault Outpoints (empty array equivalent to no filter) |
 
 
 ### Response

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -89,12 +89,9 @@ fn socket_file(conf_file: Option<PathBuf>) -> PathBuf {
         eprintln!("Error getting config: {}", e);
         process::exit(1);
     });
-    let data_dir = config.data_dir.unwrap_or_else(|| {
-        config_folder_path().unwrap_or_else(|e| {
-            eprintln!("{}", e);
-            process::exit(1);
-        })
-    });
+    let data_dir = config
+        .data_dir
+        .unwrap_or_else(|| config_folder_path().unwrap());
     let data_dir = data_dir.to_str().expect("Datadir is valid unicode");
 
     [

--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -1,9 +1,14 @@
 use revault_net::sodiumoxide;
 use revault_tx::bitcoin::hashes::hex::ToHex;
-use std::{env, path::PathBuf, process, time};
+use std::{
+    env,
+    io::{self, Write},
+    path::PathBuf,
+    process, time,
+};
 
 use daemonize_simple::Daemonize;
-use revaultd::{config::Config, daemon_start, rpc_server_loop, RevaultD};
+use revaultd::{config::Config, DaemonHandle, RevaultD};
 
 fn parse_args(args: Vec<String>) -> Option<PathBuf> {
     if args.len() == 1 {
@@ -94,6 +99,10 @@ fn main() {
         println!("Started revaultd daemon");
     }
 
-    let daemon_handle = daemon_start(revaultd);
-    rpc_server_loop(daemon_handle);
+    let daemon_handle = DaemonHandle::start(revaultd);
+    daemon_handle.rpc_server();
+
+    // We are always logging to stdout, should it be then piped to the log file (if self) or
+    // not. So just make sure that all messages were actually written.
+    io::stdout().flush().expect("Flushing stdout");
 }

--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -3,7 +3,7 @@ use revault_tx::bitcoin::hashes::hex::ToHex;
 use std::{env, path::PathBuf, process, time};
 
 use daemonize_simple::Daemonize;
-use revaultd::{config::Config, daemon_main, RevaultD};
+use revaultd::{config::Config, daemon_start, rpc_server_loop, RevaultD};
 
 fn parse_args(args: Vec<String>) -> Option<PathBuf> {
     if args.len() == 1 {
@@ -94,5 +94,6 @@ fn main() {
         println!("Started revaultd daemon");
     }
 
-    daemon_main(revaultd);
+    let daemon_handle = daemon_start(revaultd);
+    rpc_server_loop(daemon_handle);
 }

--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -108,7 +108,12 @@ fn main() {
         println!("Started revaultd daemon");
     }
 
-    daemon_handle.rpc_server();
+    // Listen for incoming commands, then shutdown when we are stopped
+    daemon_handle
+        .rpc_server()
+        .expect("Fatal error in JSONRPC server");
+    log::info!("Stopping revaultd");
+    daemon_handle.shutdown();
 
     // We are always logging to stdout, should it be then piped to the log file (if self) or
     // not. So just make sure that all messages were actually written.

--- a/src/bitcoind/interface.rs
+++ b/src/bitcoind/interface.rs
@@ -22,6 +22,7 @@ use jsonrpc::{
     client::Client,
     simple_http::{Error as HttpError, SimpleHttpTransport},
 };
+use serde::Serialize;
 use serde_json::Value as Json;
 
 // The minimum deposit value according to revault_tx depends also on the unvault's
@@ -919,9 +920,10 @@ impl BitcoinD {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct WalletTransaction {
     pub hex: String,
+    #[serde(rename = "received_at")]
     pub received_time: u32,
     // None if unconfirmed
     pub blockheight: Option<u32>,

--- a/src/bitcoind/mod.rs
+++ b/src/bitcoind/mod.rs
@@ -164,8 +164,9 @@ fn wallet_transaction(bitcoind: &BitcoinD, txid: Txid) -> Option<WalletTransacti
 pub fn bitcoind_main_loop(
     rx: Receiver<BitcoindMessageOut>,
     revaultd: Arc<RwLock<RevaultD>>,
-    bitcoind: Arc<RwLock<BitcoinD>>,
+    bitcoind: BitcoinD,
 ) -> Result<(), BitcoindError> {
+    let bitcoind = Arc::new(RwLock::new(bitcoind));
     // The verification progress announced by bitcoind *at startup* thus won't be updated
     // after startup check. Should be *exactly* 1.0 when synced, but hey, floats so we are
     // careful.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,1421 @@
+//! # Revault daemon command interface.
+//!
+//! This module regroups multiple commands to query or alter the state of the Revault daemon.
+//! All commands here assume an accessible and sane database. They will **panic** on a failure
+//! to query it.
+
+pub use crate::{
+    bitcoind::{interface::WalletTransaction, BitcoindError},
+    communication::ServerStatus,
+};
+use crate::{
+    communication::{
+        announce_spend_transaction, check_spend_transaction_size, coord_share_rev_signatures,
+        coordinator_status, cosigners_status, fetch_cosigs_signatures, share_unvault_signatures,
+        watchtowers_status, wts_share_emer_signatures, wts_share_second_stage_signatures,
+        CommunicationError,
+    },
+    control::{
+        finalized_emer_txs, gethistory, listvaults_from_db, presigned_txs, vaults_from_deposits,
+        HistoryEvent, HistoryEventKind, ListVaultsEntry, VaultPresignedTransaction,
+    },
+    database::{
+        actions::{
+            db_delete_spend, db_insert_spend, db_mark_activating_vault,
+            db_mark_broadcastable_spend, db_mark_securing_vault, db_update_presigned_txs,
+            db_update_spend, db_update_vault_status,
+        },
+        interface::{
+            db_cancel_transaction, db_emer_transaction, db_list_spends, db_spend_transaction,
+            db_tip, db_unvault_emer_transaction, db_unvault_transaction, db_vault_by_deposit,
+            db_vault_by_unvault_txid, db_vaults, db_vaults_from_spend, db_vaults_min_status,
+        },
+    },
+    revaultd::{BlockchainTip, RevaultD, VaultStatus},
+    threadmessages::BitcoindThread,
+    utils::ser_to_string,
+    VERSION,
+};
+
+use revault_tx::{
+    bitcoin::{
+        consensus::encode, secp256k1, util::bip32, Address, Amount, Network, OutPoint,
+        PublicKey as BitcoinPubKey, Transaction as BitcoinTransaction, TxOut, Txid,
+    },
+    miniscript::DescriptorTrait,
+    scripts::{CpfpDescriptor, DepositDescriptor, UnvaultDescriptor},
+    transactions::{
+        spend_tx_from_deposits, transaction_chain, CancelTransaction, CpfpableTransaction,
+        EmergencyTransaction, RevaultTransaction, SpendTransaction, UnvaultEmergencyTransaction,
+        UnvaultTransaction,
+    },
+    txins::DepositTxIn,
+    txouts::{DepositTxOut, SpendTxOut},
+};
+
+use std::{collections::BTreeMap, fmt};
+
+use serde::{Deserialize, Serialize};
+
+/// An error raised when calling a command
+#[derive(Debug)]
+pub enum CommandError {
+    UnknownOutpoint(OutPoint),
+    /// (Got, Expected)
+    InvalidStatus(VaultStatus, VaultStatus),
+    InvalidStatusFor(VaultStatus, OutPoint),
+    // TODO: remove in favour of specific variants
+    InvalidParams(String),
+    Communication(CommunicationError),
+    Bitcoind(BitcoindError),
+    Tx(revault_tx::Error),
+    /// (Required, Actual)
+    SpendFeerateTooLow(u64, u64),
+    SpendTooLarge,
+    SpendUnknownUnVault(Txid),
+    UnknownSpend(Txid),
+    SpendSpent(Txid),
+    /// (Got, Expected)
+    SpendNotEnoughSig(usize, usize),
+    SpendInvalidSig(Vec<u8>),
+    MissingCpfpKey,
+    ManagerOnly,
+    StakeholderOnly,
+    Race,
+}
+
+impl fmt::Display for CommandError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::UnknownOutpoint(op) => write!(f, "No vault at '{}'", op),
+            Self::InvalidStatus(got, expected) => {
+                write!(f, "Invalid vault status: '{}'. Need '{}'.", got, expected)
+            }
+            Self::InvalidStatusFor(status, outpoint) => write!(
+                f,
+                "Invalid vault status '{}' for deposit outpoint '{}'",
+                status, outpoint
+            ),
+            Self::InvalidParams(e) => write!(f, "{}", e),
+            Self::Communication(e) => write!(f, "Communication error: '{}'", e),
+            Self::Bitcoind(e) => write!(f, "Bitcoind error: '{}'", e),
+            Self::Tx(e) => write!(f, "Transaction related error: '{}'", e),
+            Self::SpendFeerateTooLow(req, actual) => write!(
+                f,
+                "Required feerate ('{}') is significantly higher than actual feerate ('{}')",
+                req, actual
+            ),
+            Self::SpendTooLarge => write!(
+                f,
+                "Spend transaction is too large, try spending less outpoints"
+            ),
+            Self::SpendUnknownUnVault(txid) => {
+                write!(f, "Spend transaction refers an unknown Unvault: '{}'", txid)
+            }
+            Self::UnknownSpend(txid) => {
+                write!(f, "Unknown Spend transaction '{}'", txid)
+            }
+            Self::SpendSpent(txid) => {
+                write!(f, "Spend '{}' refers to a spent vault", txid)
+            }
+            Self::MissingCpfpKey => {
+                write!(
+                    f,
+                    "Can't read the cpfp key. Make sure you have a file called \
+                     cpfp_secret containing the private key in your datadir and \
+                     restart the daemon."
+                )
+            }
+            Self::SpendNotEnoughSig(got, req) => {
+                write!(
+                    f,
+                    "Not enough signatures, needed: {}, current: {}",
+                    req, got
+                )
+            }
+            Self::SpendInvalidSig(sig) => {
+                write!(
+                    f,
+                    "Spend PSBT contains an invalid signature: '{}'",
+                    encode::serialize_hex(&sig)
+                )
+            }
+            Self::StakeholderOnly => {
+                write!(f, "This is a stakeholder command")
+            }
+            Self::ManagerOnly => {
+                write!(f, "This is a manager command")
+            }
+            Self::Race => write!(f, "Internal error due to a race. Please try again."),
+        }
+    }
+}
+
+impl std::error::Error for CommandError {}
+
+impl From<BitcoindError> for CommandError {
+    fn from(e: BitcoindError) -> Self {
+        Self::Bitcoind(e)
+    }
+}
+
+impl From<CommunicationError> for CommandError {
+    fn from(e: CommunicationError) -> Self {
+        Self::Communication(e)
+    }
+}
+
+impl From<revault_tx::Error> for CommandError {
+    fn from(e: revault_tx::Error) -> Self {
+        Self::Tx(e)
+    }
+}
+
+macro_rules! stakeholder_only {
+    ($revaultd:ident) => {
+        if !$revaultd.is_stakeholder() {
+            return Err(CommandError::StakeholderOnly);
+        }
+    };
+}
+
+macro_rules! manager_only {
+    ($revaultd:ident) => {
+        if !$revaultd.is_manager() {
+            return Err(CommandError::ManagerOnly);
+        }
+    };
+}
+
+/// Descriptors the daemon was configured with
+#[derive(Debug, Clone, Serialize)]
+pub struct GetInfoDescriptors {
+    #[serde(serialize_with = "ser_to_string")]
+    pub deposit: DepositDescriptor,
+    #[serde(serialize_with = "ser_to_string")]
+    pub unvault: UnvaultDescriptor,
+    #[serde(serialize_with = "ser_to_string")]
+    pub cpfp: CpfpDescriptor,
+}
+
+/// Information about the current state of the daemon
+#[derive(Debug, Clone, Serialize)]
+pub struct GetInfoResult {
+    pub version: String,
+    pub network: Network,
+    pub blockheight: i32,
+    pub sync: f64,
+    pub vaults: usize,
+    pub managers_threshold: usize,
+    pub descriptors: GetInfoDescriptors,
+}
+
+/// Get information about the current state of the daemon
+pub fn getinfo(revaultd: &RevaultD, bitcoind: &impl BitcoindThread) -> GetInfoResult {
+    // This means blockheight == 0 for IBD.
+    let BlockchainTip {
+        height: blockheight,
+        ..
+    } = db_tip(&revaultd.db_file()).expect("Database must not be dead");
+    let number_of_vaults = listvaults(&revaultd, None, None)
+        .vaults
+        .iter()
+        .filter(|l| {
+            l.status != VaultStatus::Spent
+                && l.status != VaultStatus::Canceled
+                && l.status != VaultStatus::Unvaulted
+                && l.status != VaultStatus::EmergencyVaulted
+        })
+        .count();
+
+    GetInfoResult {
+        version: VERSION.to_string(),
+        network: revaultd.bitcoind_config.network,
+        blockheight: blockheight as i32,
+        sync: bitcoind.sync_progress(),
+        vaults: number_of_vaults,
+        managers_threshold: revaultd.managers_threshold(),
+        descriptors: GetInfoDescriptors {
+            deposit: revaultd.deposit_descriptor.clone(),
+            unvault: revaultd.unvault_descriptor.clone(),
+            cpfp: revaultd.cpfp_descriptor.clone(),
+        },
+    }
+}
+
+/// Information about all our current vaults
+#[derive(Debug, Clone, Serialize)]
+pub struct ListVaultsResult {
+    pub vaults: Vec<ListVaultsEntry>,
+}
+
+/// List the current vaults, optionally filtered by status and/or deposit outpoints.
+pub fn listvaults(
+    revaultd: &RevaultD,
+    statuses: Option<Vec<VaultStatus>>,
+    deposit_outpoints: Option<Vec<OutPoint>>,
+) -> ListVaultsResult {
+    ListVaultsResult {
+        vaults: listvaults_from_db(revaultd, statuses, deposit_outpoints)
+            .expect("Database must be available"),
+    }
+}
+
+/// Revocation transactions for a given vault
+#[derive(Debug, Clone, Serialize)]
+pub struct RevocationTransactions {
+    pub cancel_tx: CancelTransaction,
+    pub emergency_tx: EmergencyTransaction,
+    // FIXME: consistent naming
+    pub emergency_unvault_tx: UnvaultEmergencyTransaction,
+}
+
+/// Get the revocation transactions for the vault identified by this outpoint.
+/// Returns None if there are no *confirmed* vault at this outpoint.
+///
+/// ## Errors
+/// - If called by a non-stakeholder
+/// - If called for an unknown or unconfirmed vault
+pub fn getrevocationtxs(
+    revaultd: &RevaultD,
+    deposit_outpoint: OutPoint,
+) -> Result<RevocationTransactions, CommandError> {
+    stakeholder_only!(revaultd);
+    let db_path = &revaultd.db_file();
+
+    // First, make sure the vault exists and is confirmed.
+    let vault = db_vault_by_deposit(db_path, &deposit_outpoint)
+        .expect("Database must be available")
+        .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
+    if matches!(vault.status, VaultStatus::Unconfirmed) {
+        return Err(CommandError::InvalidStatus(
+            vault.status,
+            VaultStatus::Funded,
+        ));
+    };
+
+    let emer_address = revaultd
+        .emergency_address
+        .clone()
+        .expect("Must be stakeholder");
+    let (_, cancel_tx, emergency_tx, emergency_unvault_tx) = transaction_chain(
+        deposit_outpoint,
+        vault.amount,
+        &revaultd.deposit_descriptor,
+        &revaultd.unvault_descriptor,
+        &revaultd.cpfp_descriptor,
+        vault.derivation_index,
+        emer_address,
+        revaultd.lock_time,
+        &revaultd.secp_ctx,
+    )
+    .expect("We wouldn't have put a vault with an invalid chain in DB");
+
+    Ok(RevocationTransactions {
+        cancel_tx,
+        emergency_tx,
+        emergency_unvault_tx,
+    })
+}
+
+/// Set the signed revocation transactions for the vault at this outpoint.
+///
+/// ## Errors
+/// - If called for a non-stakeholder
+/// - If called for an unknown or not 'funded' vault
+/// - If given insane revocation txs PSBTs (without our signatures, with invalid sigs, ..)
+pub fn revocationtxs(
+    revaultd: &RevaultD,
+    deposit_outpoint: OutPoint,
+    cancel_tx: CancelTransaction,
+    emergency_tx: EmergencyTransaction,
+    unvault_emergency_tx: UnvaultEmergencyTransaction,
+) -> Result<(), CommandError> {
+    stakeholder_only!(revaultd);
+    let db_path = revaultd.db_file();
+    let secp_ctx = &revaultd.secp_ctx;
+
+    assert!(revaultd.is_stakeholder());
+
+    // They may only send revocation transactions for confirmed and not-yet-presigned
+    // vaults.
+    let db_vault = db_vault_by_deposit(&db_path, &deposit_outpoint)
+        .expect("Database must be available")
+        .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
+    if !matches!(db_vault.status, VaultStatus::Funded) {
+        return Err(CommandError::InvalidStatus(
+            db_vault.status,
+            VaultStatus::Funded,
+        ));
+    };
+
+    // Sanity check they didn't send us garbaged PSBTs
+    let mut cancel_db_tx = db_cancel_transaction(&db_path, db_vault.id)
+        .expect("The database must be available")
+        .ok_or(CommandError::Race)?;
+    let rpc_txid = cancel_tx.tx().wtxid();
+    let db_txid = cancel_db_tx.psbt.wtxid();
+    if rpc_txid != db_txid {
+        return Err(CommandError::InvalidParams(format!(
+            "Invalid Cancel tx: db wtxid is '{}' but this PSBT's is '{}' ",
+            db_txid, rpc_txid
+        )));
+    }
+    let mut emer_db_tx = db_emer_transaction(&revaultd.db_file(), db_vault.id)
+        .expect("The database must be available")
+        .ok_or(CommandError::Race)?;
+    let rpc_txid = emergency_tx.tx().wtxid();
+    let db_txid = emer_db_tx.psbt.wtxid();
+    if rpc_txid != db_txid {
+        return Err(CommandError::InvalidParams(format!(
+            "Invalid Emergency tx: db wtxid is '{}' but this PSBT's is '{}' ",
+            db_txid, rpc_txid
+        )));
+    }
+    let mut unvault_emer_db_tx = db_unvault_emer_transaction(&revaultd.db_file(), db_vault.id)
+        .expect("The database must be available")
+        .ok_or(CommandError::Race)?;
+    let rpc_txid = unvault_emergency_tx.tx().wtxid();
+    let db_txid = unvault_emer_db_tx.psbt.wtxid();
+    if rpc_txid != db_txid {
+        return Err(CommandError::InvalidParams(format!(
+            "Invalid Unvault Emergency tx: db wtxid is '{}' but this PSBT's is '{}' ",
+            db_txid, rpc_txid
+        )));
+    }
+
+    // Alias some vars we'll reuse
+    let deriv_index = db_vault.derivation_index;
+    let cancel_sigs = &cancel_tx
+        .psbt()
+        .inputs
+        .get(0)
+        .expect("Cancel tx has a single input, inbefore fee bumping.")
+        .partial_sigs;
+    let emer_sigs = &emergency_tx
+        .psbt()
+        .inputs
+        .get(0)
+        .expect("Emergency tx has a single input, inbefore fee bumping.")
+        .partial_sigs;
+    let unvault_emer_sigs = &unvault_emergency_tx
+        .psbt()
+        .inputs
+        .get(0)
+        .expect("UnvaultEmergency tx has a single input, inbefore fee bumping.")
+        .partial_sigs;
+
+    // They must have included *at least* a signature for our pubkey
+    let our_pubkey = revaultd
+        .our_stk_xpub_at(deriv_index)
+        .expect("We are a stakeholder, checked at the beginning of the call.");
+    if !cancel_sigs.contains_key(&our_pubkey) {
+        return Err(CommandError::InvalidParams(format!(
+            "No signature for ourselves ({}) in Cancel transaction",
+            our_pubkey
+        )));
+    }
+    // We use the same public key across the transaction chain, that's pretty
+    // neat from an usability perspective.
+    if !emer_sigs.contains_key(&our_pubkey) {
+        return Err(CommandError::InvalidParams(
+            "No signature for ourselves in Emergency transaction".to_string(),
+        ));
+    }
+    if !unvault_emer_sigs.contains_key(&our_pubkey) {
+        return Err(CommandError::InvalidParams(
+            "No signature for ourselves in UnvaultEmergency transaction".to_string(),
+        ));
+    }
+
+    // There is no reason for them to include an unnecessary signature, so be strict.
+    let stk_keys = revaultd.stakeholders_xpubs_at(deriv_index);
+    for (ref key, _) in cancel_sigs.iter() {
+        if !stk_keys.contains(key) {
+            return Err(CommandError::InvalidParams(format!(
+                "Unknown key in Cancel transaction signatures: {}",
+                key
+            )));
+        }
+    }
+    for (ref key, _) in emer_sigs.iter() {
+        if !stk_keys.contains(key) {
+            return Err(CommandError::InvalidParams(format!(
+                "Unknown key in Emergency transaction signatures: {}",
+                key
+            )));
+        }
+    }
+    for (ref key, _) in unvault_emer_sigs.iter() {
+        if !stk_keys.contains(key) {
+            return Err(CommandError::InvalidParams(format!(
+                "Unknown key in UnvaultEmergency transaction signatures: {}",
+                key
+            )));
+        }
+    }
+
+    // Add the signatures to the DB transactions.
+    for (key, sig) in cancel_sigs {
+        if sig.is_empty() {
+            return Err(CommandError::InvalidParams(format!(
+                "Empty signature for key '{}' in Cancel PSBT",
+                key
+            )));
+        }
+        let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+            CommandError::InvalidParams(format!("Non DER signature in Cancel PSBT"))
+        })?;
+        cancel_db_tx
+            .psbt
+            .add_signature(key.key, sig, secp_ctx)
+            .map_err(|e| {
+                CommandError::InvalidParams(format!(
+                    "Invalid signature '{}' in Cancel PSBT: '{}'",
+                    sig, e
+                ))
+            })?;
+    }
+    for (key, sig) in emer_sigs {
+        if sig.is_empty() {
+            return Err(CommandError::InvalidParams(format!(
+                "Empty signature for key '{}' in Emergency PSBT",
+                key
+            )));
+        }
+        let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+            CommandError::InvalidParams(format!("Non DER signature in Emergency PSBT"))
+        })?;
+        emer_db_tx
+            .psbt
+            .add_signature(key.key, sig, secp_ctx)
+            .map_err(|e| {
+                CommandError::InvalidParams(format!(
+                    "Invalid signature '{}' in Emergency PSBT: '{}'",
+                    sig, e
+                ))
+            })?;
+    }
+    for (key, sig) in unvault_emer_sigs {
+        if sig.is_empty() {
+            return Err(CommandError::InvalidParams(format!(
+                "Empty signature for key '{}' in UnvaultEmergency PSBT",
+                key
+            )));
+        }
+        let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+            CommandError::InvalidParams(format!("Non DER signature in UnvaultEmergency PSBT",))
+        })?;
+        unvault_emer_db_tx
+            .psbt
+            .add_signature(key.key, sig, secp_ctx)
+            .map_err(|e| {
+                CommandError::InvalidParams(format!(
+                    "Invalid signature '{}' in UnvaultEmergency PSBT: '{}'",
+                    sig, e
+                ))
+            })?;
+    }
+
+    // Then add them to the PSBTs in database. Take care to update the vault
+    // status if all signatures were given via the RPC.
+    let rev_txs = vec![cancel_db_tx, emer_db_tx, unvault_emer_db_tx];
+    db_update_presigned_txs(&db_path, &db_vault, rev_txs.clone(), secp_ctx)
+        .expect("The database must be available");
+    db_mark_securing_vault(&db_path, db_vault.id).expect("The database must be available");
+
+    // If this made the Emergency fully signed and we are a stakeholder, share
+    // it with our watchtowers.
+    let emer_db_tx = db_emer_transaction(&db_path, db_vault.id)
+        .expect("The database must be available")
+        .ok_or(CommandError::Race)?;
+    if !db_vault.emer_shared && emer_db_tx.psbt.unwrap_emer().is_finalizable(secp_ctx) {
+        if let Some(ref watchtowers) = revaultd.watchtowers {
+            wts_share_emer_signatures(
+                &revaultd.noise_secret,
+                &watchtowers,
+                db_vault.deposit_outpoint,
+                db_vault.derivation_index,
+                &emer_db_tx,
+            )?;
+        }
+    }
+    db_update_vault_status(&db_path, &db_vault).expect("The database must be available");
+
+    // Share them with our felow stakeholders.
+    coord_share_rev_signatures(
+        revaultd.coordinator_host,
+        &revaultd.noise_secret,
+        &revaultd.coordinator_noisekey,
+        &rev_txs,
+    )?;
+
+    Ok(())
+}
+
+/// Get the unvault transaction for the vault identified by this outpoint.
+/// Returns None if there are no *confirmed* vault at this outpoint.
+///
+/// ## Errors
+/// - If called for a non stakeholder
+/// - If called for an unknown or not 'funded' vault
+pub fn get_unvault_tx(
+    revaultd: &RevaultD,
+    deposit_outpoint: OutPoint,
+) -> Result<UnvaultTransaction, CommandError> {
+    stakeholder_only!(revaultd);
+    let db_path = &revaultd.db_file();
+    assert!(revaultd.is_stakeholder());
+
+    // We allow the call for Funded 'only' as unvaulttx would later fail if it's
+    // not 'secured'.
+    let vault = db_vault_by_deposit(db_path, &deposit_outpoint)
+        .expect("The database must be available")
+        .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
+    if matches!(vault.status, VaultStatus::Unconfirmed) {
+        return Err(CommandError::InvalidStatus(
+            vault.status,
+            VaultStatus::Funded,
+        ));
+    }
+
+    // Derive the descriptors needed to create the UnvaultTransaction
+    let deposit_descriptor = revaultd
+        .deposit_descriptor
+        .derive(vault.derivation_index, &revaultd.secp_ctx);
+    let deposit_txin = DepositTxIn::new(
+        deposit_outpoint,
+        DepositTxOut::new(vault.amount, &deposit_descriptor),
+    );
+    let unvault_descriptor = revaultd
+        .unvault_descriptor
+        .derive(vault.derivation_index, &revaultd.secp_ctx);
+    let cpfp_descriptor = revaultd
+        .cpfp_descriptor
+        .derive(vault.derivation_index, &revaultd.secp_ctx);
+
+    Ok(UnvaultTransaction::new(
+        deposit_txin,
+        &unvault_descriptor,
+        &cpfp_descriptor,
+        revaultd.lock_time,
+    )
+    .expect("We wouldn't have a vault with an invalid Unvault in DB"))
+}
+
+/// Set the signed unvault transaction for the vault at this outpoint.
+///
+/// ## Errors
+/// - If called for a non-stakeholder
+/// - If called for an unknown or not 'secured' vault
+/// - If passed an insane Unvault transaction (no sig for ourselves, invalid sig, ..)
+pub fn set_unvault_tx(
+    revaultd: &RevaultD,
+    deposit_outpoint: OutPoint,
+    unvault_tx: UnvaultTransaction,
+) -> Result<(), CommandError> {
+    stakeholder_only!(revaultd);
+    let db_path = revaultd.db_file();
+    let secp_ctx = &revaultd.secp_ctx;
+
+    // If they haven't got all the signatures for the revocation transactions, we'd
+    // better not send our unvault sig!
+    // If the vault is already active (or more) there is no point in spamming the
+    // coordinator.
+    let db_vault = db_vault_by_deposit(&db_path, &deposit_outpoint)
+        .expect("The database must be available")
+        .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
+    if !matches!(db_vault.status, VaultStatus::Secured) {
+        return Err(CommandError::InvalidStatus(
+            db_vault.status,
+            VaultStatus::Secured,
+        ));
+    }
+
+    // Sanity check they didn't send us a garbaged PSBT
+    let mut unvault_db_tx = db_unvault_transaction(&db_path, db_vault.id)
+        .expect("The database must be available")
+        .ok_or(CommandError::Race)?;
+    let rpc_txid = unvault_tx.tx().wtxid();
+    let db_txid = unvault_db_tx.psbt.wtxid();
+    if rpc_txid != db_txid {
+        return Err(CommandError::InvalidParams(format!(
+            "Invalid Unvault tx: db wtxid is '{}' but this PSBT's is '{}' ",
+            db_txid, rpc_txid
+        )));
+    }
+
+    let sigs = &unvault_tx
+        .psbt()
+        .inputs
+        .get(0)
+        .expect("UnvaultTransaction always has 1 input")
+        .partial_sigs;
+    let stk_keys = revaultd.stakeholders_xpubs_at(db_vault.derivation_index);
+    let our_key = revaultd
+        .our_stk_xpub_at(db_vault.derivation_index)
+        .expect("We are a stakeholder, checked at the beginning.");
+    // They must have included *at least* a signature for our pubkey, and must not include an
+    // unnecessary signature.
+    if !sigs.contains_key(&our_key) {
+        return Err(CommandError::InvalidParams(format!(
+            "No signature for ourselves ({}) in Unvault transaction",
+            our_key
+        )));
+    }
+
+    for (key, sig) in sigs {
+        // There is no reason for them to include an unnecessary signature, so be strict.
+        if !stk_keys.contains(&key) {
+            return Err(CommandError::InvalidParams(format!(
+                "Unknown key in Unvault transaction signatures: {}",
+                key
+            )));
+        }
+
+        if sig.is_empty() {
+            return Err(CommandError::InvalidParams(format!(
+                "Empty signature for key '{}' in Unvault PSBT",
+                key
+            )));
+        }
+        let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+            CommandError::InvalidParams(format!("Non DER signature in Unvault PSBT"))
+        })?;
+
+        unvault_db_tx
+            .psbt
+            .add_signature(key.key, sig, secp_ctx)
+            .map_err(|e| {
+                CommandError::InvalidParams(format!(
+                    "Invalid signature '{}' in Unvault PSBT: '{}'",
+                    sig, e
+                ))
+            })?;
+    }
+
+    // The watchtower(s) MUST have our second-stage (UnvaultEmer, Cancel) signatures
+    // before we share the Unvault one.
+    if let Some(ref watchtowers) = revaultd.watchtowers {
+        let unemer_db_tx = db_unvault_emer_transaction(&db_path, db_vault.id)
+            .expect("The database must be available")
+            .ok_or(CommandError::Race)?;
+        let cancel_db_tx = db_cancel_transaction(&db_path, db_vault.id)
+            .expect("The database must be available")
+            .ok_or(CommandError::Race)?;
+        wts_share_second_stage_signatures(
+            &revaultd.noise_secret,
+            &watchtowers,
+            db_vault.deposit_outpoint,
+            db_vault.derivation_index,
+            &cancel_db_tx,
+            &unemer_db_tx,
+        )?;
+    }
+
+    // Sanity checks passed. Store it then share it.
+    db_update_presigned_txs(&db_path, &db_vault, vec![unvault_db_tx.clone()], secp_ctx)
+        .expect("The database must be available");
+    db_mark_activating_vault(&db_path, db_vault.id).expect("The database must be available");
+    db_update_vault_status(&db_path, &db_vault).expect("The database must be available");
+    share_unvault_signatures(
+        revaultd.coordinator_host,
+        &revaultd.noise_secret,
+        &revaultd.coordinator_noisekey,
+        &unvault_db_tx,
+    )?;
+
+    Ok(())
+}
+
+/// Information about a vault's presigned transactions.
+#[derive(Debug, Clone, Serialize)]
+pub struct ListPresignedTxEntry {
+    pub vault_outpoint: OutPoint,
+    pub unvault: VaultPresignedTransaction<UnvaultTransaction>,
+    pub cancel: VaultPresignedTransaction<CancelTransaction>,
+    /// Always None if not stakeholder
+    pub emergency: Option<VaultPresignedTransaction<EmergencyTransaction>>,
+    /// Always None if not stakeholder
+    pub unvault_emergency: Option<VaultPresignedTransaction<UnvaultEmergencyTransaction>>,
+}
+
+/// List the presigned transactions for the vaults at these outpoints. If `outpoints` is empty,
+/// list the presigned transactions for all vaults.
+///
+/// # Errors
+/// - If an outpoint does not refer to a known deposit, or if the status of the vault is
+/// part of `invalid_statuses`.
+pub fn presigned_transactions(
+    revaultd: &RevaultD,
+    outpoints: &[OutPoint],
+) -> Result<Vec<ListPresignedTxEntry>, CommandError> {
+    let db_path = revaultd.db_file();
+    let db_vaults = if outpoints.is_empty() {
+        db_vaults_min_status(&db_path, VaultStatus::Funded).expect("Database must be available")
+    } else {
+        vaults_from_deposits(&db_path, &outpoints, &[VaultStatus::Unconfirmed])?
+    };
+
+    presigned_txs(&revaultd, db_vaults).ok_or(CommandError::Race)
+}
+
+/// Information about a vault's onchain transactions.
+#[derive(Debug, Clone, Serialize)]
+pub struct ListOnchainTxEntry {
+    pub vault_outpoint: OutPoint,
+    pub deposit: WalletTransaction,
+    pub unvault: Option<WalletTransaction>,
+    pub cancel: Option<WalletTransaction>,
+    /// Always None if not stakeholder
+    pub emergency: Option<WalletTransaction>,
+    /// Always None if not stakeholder
+    pub unvault_emergency: Option<WalletTransaction>,
+    pub spend: Option<WalletTransaction>,
+}
+
+/// List the onchain transactions for the vaults at these outpoints. If `outpoints` is empty, list
+/// the onchain transactions for all vaults.
+///
+/// # Errors
+/// - If an outpoint does not refer to a known deposit, or if the status of the vault is
+/// part of `invalid_statuses`.
+pub fn onchain_transactions(
+    revaultd: &RevaultD,
+    bitcoind_conn: &impl BitcoindThread,
+    outpoints: &[OutPoint],
+) -> Result<Vec<ListOnchainTxEntry>, CommandError> {
+    let db_path = &revaultd.db_file();
+
+    let db_vaults = if outpoints.is_empty() {
+        db_vaults(&db_path).expect("Database must be available")
+    } else {
+        // We accept any status
+        vaults_from_deposits(&db_path, &outpoints, &[])?
+    };
+
+    let mut tx_list = Vec::with_capacity(db_vaults.len());
+    for db_vault in db_vaults {
+        let vault_outpoint = db_vault.deposit_outpoint;
+
+        // If the vault exist, there must always be a deposit transaction available.
+        let deposit = bitcoind_conn
+            .wallet_tx(db_vault.deposit_outpoint.txid)?
+            .expect("Vault exists but not deposit tx?");
+
+        // For the other transactions, it depends on the status of the vault. For the sake of
+        // simplicity bitcoind will tell us (but we could have some optimisation eventually here,
+        // eg returning None early on Funded vaults).
+        let (unvault, cancel, emergency, unvault_emergency, spend) = match db_vault.status {
+            VaultStatus::Unvaulting | VaultStatus::Unvaulted => {
+                let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
+                    .expect("Database must be available")
+                    .ok_or(CommandError::Race)?;
+                let unvault = bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
+                (unvault, None, None, None, None)
+            }
+            VaultStatus::Spending | VaultStatus::Spent => {
+                let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
+                    .expect("Database must be available")
+                    .ok_or(CommandError::Race)?;
+                let unvault = bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
+                let spend = if let Some(spend_txid) = db_vault.final_txid {
+                    bitcoind_conn.wallet_tx(spend_txid)?
+                } else {
+                    None
+                };
+                (unvault, None, None, None, spend)
+            }
+            VaultStatus::Canceling | VaultStatus::Canceled => {
+                let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
+                    .expect("Database must be available")
+                    .ok_or(CommandError::Race)?;
+                let unvault = bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
+                let cancel = if let Some(cancel_txid) = db_vault.final_txid {
+                    bitcoind_conn.wallet_tx(cancel_txid)?
+                } else {
+                    None
+                };
+                (unvault, cancel, None, None, None)
+            }
+            VaultStatus::EmergencyVaulting | VaultStatus::EmergencyVaulted => {
+                // Emergencies are only for stakeholders!
+                if revaultd.is_stakeholder() {
+                    let emer_db_tx = db_emer_transaction(db_path, db_vault.id)
+                        .expect("Database must be available")
+                        .ok_or(CommandError::Race)?;
+                    let emergency = bitcoind_conn.wallet_tx(emer_db_tx.psbt.txid())?;
+                    (None, None, emergency, None, None)
+                } else {
+                    (None, None, None, None, None)
+                }
+            }
+            VaultStatus::UnvaultEmergencyVaulting | VaultStatus::UnvaultEmergencyVaulted => {
+                let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
+                    .expect("Database must be available")
+                    .ok_or(CommandError::Race)?;
+                let unvault = bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
+
+                // Emergencies are only for stakeholders!
+                if revaultd.is_stakeholder() {
+                    let unemer_db_tx = db_emer_transaction(db_path, db_vault.id)
+                        .expect("Database must be available")
+                        .ok_or(CommandError::Race)?;
+                    let unvault_emergency = bitcoind_conn.wallet_tx(unemer_db_tx.psbt.txid())?;
+                    (unvault, None, None, unvault_emergency, None)
+                } else {
+                    (unvault, None, None, None, None)
+                }
+            }
+            // Other statuses do not have on chain transactions apart the deposit.
+            VaultStatus::Unconfirmed
+            | VaultStatus::Funded
+            | VaultStatus::Securing
+            | VaultStatus::Secured
+            | VaultStatus::Activating
+            | VaultStatus::Active => (None, None, None, None, None),
+        };
+
+        tx_list.push(ListOnchainTxEntry {
+            vault_outpoint,
+            deposit,
+            unvault,
+            cancel,
+            emergency,
+            unvault_emergency,
+            spend,
+        });
+    }
+
+    Ok(tx_list)
+}
+
+/// Create a Spend transaction for these deposit outpoints, paying to the specified addresses
+/// at the given feerate (with a tolerance of 10% below it and any % above it if we can't create
+/// a change output).
+/// Mind we add a CPFP output, which must be taken into account by the feerate.
+///
+/// # Errors
+/// - If called for a non-manager
+/// - If provided outpoints for unknown or not 'active' vaults
+/// - If the Spend transaction creation fails (for instance due to too-high fees or dust outputs)
+/// - If the created Spend transaction's feerate is more than 10% below the required feerate
+/// - If the created Spend transaction is too large to be transmitted to the coordinator
+pub fn get_spend_tx(
+    revaultd: &RevaultD,
+    outpoints: &[OutPoint],
+    destinations: BTreeMap<Address, u64>,
+    feerate_vb: u64,
+) -> Result<SpendTransaction, CommandError> {
+    manager_only!(revaultd);
+    let db_file = &revaultd.db_file();
+
+    // FIXME: have a feerate type to avoid that
+    assert!(feerate_vb > 0, "Spend feerate can't be null.");
+
+    // Reconstruct the DepositTxin s from the outpoints and the vaults informations
+    let mut txins = Vec::with_capacity(outpoints.len());
+    // If we need a change output, use the highest derivation index of the vaults
+    // spent. This avoids leaking a new address needlessly while not introducing
+    // disrepancy between our indexes.
+    let mut change_index = bip32::ChildNumber::from(0);
+    for outpoint in outpoints {
+        let vault = db_vault_by_deposit(db_file, outpoint)
+            .expect("Database must be available")
+            .ok_or_else(|| CommandError::UnknownOutpoint(*outpoint))?;
+        if matches!(vault.status, VaultStatus::Active) {
+            if vault.derivation_index > change_index {
+                change_index = vault.derivation_index;
+            }
+            txins.push((*outpoint, vault.amount, vault.derivation_index));
+        } else {
+            return Err(CommandError::InvalidStatus(
+                vault.status,
+                VaultStatus::Active,
+            ));
+        }
+    }
+
+    let txos: Vec<SpendTxOut> = destinations
+        .into_iter()
+        .map(|(addr, value)| {
+            let script_pubkey = addr.script_pubkey();
+            SpendTxOut::new(TxOut {
+                value,
+                script_pubkey,
+            })
+        })
+        .collect();
+
+    log::debug!(
+        "Creating a Spend transaction with deposit txins: '{:?}' and txos: '{:?}'",
+        &txins,
+        &txos
+    );
+
+    // This adds the CPFP output so create a dummy one to accurately compute the
+    // feerate.
+    let nochange_tx = spend_tx_from_deposits(
+        txins.clone(),
+        txos.clone(),
+        None, // No change :)
+        &revaultd.deposit_descriptor,
+        &revaultd.unvault_descriptor,
+        &revaultd.cpfp_descriptor,
+        revaultd.lock_time,
+        /* Deactivate insane feerate check */
+        false,
+        &revaultd.secp_ctx,
+    )
+    .map_err(|e| revault_tx::Error::from(e))?;
+
+    log::debug!(
+        "Spend tx without change: '{}'",
+        nochange_tx.as_psbt_string()
+    );
+
+    // If the feerate of the transaction would be much lower (< 90/100) than what they
+    // requested for, tell them.
+    let nochange_feerate_vb = nochange_tx
+        .max_feerate()
+        .checked_mul(4)
+        .expect("bug in feerate computation");
+    if nochange_feerate_vb * 10 < feerate_vb * 9 {
+        return Err(CommandError::SpendFeerateTooLow(
+            feerate_vb,
+            nochange_feerate_vb,
+        ));
+    }
+
+    // Add a change output if it would not be dust according to our standard (200k sats
+    // atm, see DUST_LIMIT).
+    // 8 (amount) + 1 (len) + 1 (v0) + 1 (push) + 32 (witscript hash)
+    const P2WSH_TXO_WEIGHT: u64 = 43 * 4;
+    let with_change_weight = nochange_tx
+        .max_weight()
+        .checked_add(P2WSH_TXO_WEIGHT)
+        .expect("weight computation bug");
+    let cur_fees = nochange_tx.fees();
+    let want_fees = with_change_weight
+        // Mental gymnastic: sat/vbyte to sat/wu rounded up
+        .checked_mul(feerate_vb + 3)
+        .map(|vbyte| vbyte.checked_div(4).unwrap());
+    let change_value = want_fees.map(|f| cur_fees.checked_sub(f)).flatten();
+    log::debug!(
+        "Weight with change: '{}'  --  Fees without change: '{}'  --  Wanted feerate: '{}'  \
+                    --  Wanted fees: '{:?}'  --  Change value: '{:?}'",
+        with_change_weight,
+        cur_fees,
+        feerate_vb,
+        want_fees,
+        change_value
+    );
+
+    let change_txo = change_value.and_then(|change_value| {
+        // The overhead incurred to the value of the CPFP output by the change output
+        // See https://github.com/revault/practical-revault/blob/master/transactions.md#spend_tx
+        let cpfp_overhead = 16 * P2WSH_TXO_WEIGHT;
+        if change_value > revault_tx::transactions::DUST_LIMIT + cpfp_overhead {
+            let change_txo = DepositTxOut::new(
+                // arithmetic checked above
+                Amount::from_sat(change_value - cpfp_overhead),
+                &revaultd
+                    .deposit_descriptor
+                    .derive(change_index, &revaultd.secp_ctx),
+            );
+            log::debug!("Adding a change txo: '{:?}'", change_txo);
+            Some(change_txo)
+        } else {
+            None
+        }
+    });
+
+    // Now we can hand them the resulting transaction (sanity checked for insane fees).
+    let tx_res = spend_tx_from_deposits(
+        txins,
+        txos,
+        change_txo,
+        &revaultd.deposit_descriptor,
+        &revaultd.unvault_descriptor,
+        &revaultd.cpfp_descriptor,
+        revaultd.lock_time,
+        true,
+        &revaultd.secp_ctx,
+    )
+    .map_err(|e| revault_tx::Error::from(e))?;
+
+    if !check_spend_transaction_size(&revaultd, tx_res.clone()) {
+        return Err(CommandError::SpendTooLarge);
+    };
+    log::debug!("Final Spend transaction: '{:?}'", tx_res);
+
+    Ok(tx_res)
+}
+
+/// Store a new or update an existing Spend transaction in database.
+///
+/// ## Errors
+/// - If called for a non-manager
+/// - If the given Spend transaction refers to an unknown Unvault txid
+/// - If the Spend refers to an Unvault of a vault that isn't 'active'
+pub fn update_spend_tx(
+    revaultd: &RevaultD,
+    spend_tx: SpendTransaction,
+) -> Result<(), CommandError> {
+    manager_only!(revaultd);
+    let db_path = revaultd.db_file();
+    let spend_txid = spend_tx.tx().txid();
+
+    // Fetch the Unvault it spends from the DB
+    let spend_inputs = &spend_tx.tx().input;
+    let mut db_unvaults = Vec::with_capacity(spend_inputs.len());
+    for txin in spend_inputs.iter() {
+        let (db_vault, db_unvault) = db_vault_by_unvault_txid(&db_path, &txin.previous_output.txid)
+            .expect("Database must be available")
+            .ok_or_else(|| CommandError::SpendUnknownUnVault(txin.previous_output.txid))?;
+
+        if !matches!(db_vault.status, VaultStatus::Active) {
+            return Err(CommandError::InvalidStatus(
+                db_vault.status,
+                VaultStatus::Active,
+            ));
+        }
+
+        db_unvaults.push(db_unvault);
+    }
+
+    // The user has the ability to set priority to the transaction in
+    // setspendtx, here we always set it to false.
+    if db_spend_transaction(&db_path, &spend_txid)
+        .expect("Database must be available")
+        .is_some()
+    {
+        log::debug!("Updating Spend transaction '{}'", spend_txid);
+        db_update_spend(&db_path, &spend_tx, false).expect("Database must be available");
+    } else {
+        log::debug!("Storing new Spend transaction '{}'", spend_txid);
+        db_insert_spend(&db_path, &db_unvaults, &spend_tx).expect("Database must be available");
+    }
+
+    Ok(())
+}
+
+/// Delete a Spend transaction by txid.
+/// **Note**: this does nothing if no Spend with this txid exist.
+///
+/// ## Errors
+/// - If called for a non-manager
+pub fn del_spend_tx(revaultd: &RevaultD, spend_txid: &Txid) -> Result<(), CommandError> {
+    manager_only!(revaultd);
+    let db_path = revaultd.db_file();
+    db_delete_spend(&db_path, spend_txid).expect("Database must be available");
+    Ok(())
+}
+
+/// Status of a Spend transaction
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ListSpendStatus {
+    NonFinal,
+    Pending,
+    Broadcasted,
+}
+
+/// Information about a Spend transaction
+#[derive(Debug, Serialize)]
+pub struct ListSpendEntry {
+    pub deposit_outpoints: Vec<OutPoint>,
+    pub psbt: SpendTransaction,
+    pub cpfp_index: usize,
+    pub change_index: Option<usize>,
+}
+
+/// List all Spend transaction, optionally curated by their status.
+///
+/// ## Errors
+/// - If called for a non-manager
+pub fn list_spend_txs(
+    revaultd: &RevaultD,
+    statuses: Option<&[ListSpendStatus]>,
+) -> Result<Vec<ListSpendEntry>, CommandError> {
+    manager_only!(revaultd);
+    let db_path = revaultd.db_file();
+
+    let spend_tx_map = db_list_spends(&db_path).expect("Database must be available");
+    let mut listspend_entries = Vec::with_capacity(spend_tx_map.len());
+    for (_, (db_spend, deposit_outpoints)) in spend_tx_map {
+        // Filter by status
+        if let Some(s) = &statuses {
+            let status = if let Some(true) = db_spend.broadcasted {
+                ListSpendStatus::Broadcasted
+            } else if let Some(false) = db_spend.broadcasted {
+                ListSpendStatus::Pending
+            } else {
+                ListSpendStatus::NonFinal
+            };
+
+            if !s.contains(&status) {
+                continue;
+            }
+        }
+
+        let spent_vaults = db_vaults_from_spend(&db_path, &db_spend.psbt.txid())
+            .expect("Database must be available");
+
+        let derivation_index = spent_vaults
+            .values()
+            .map(|v| v.derivation_index)
+            .max()
+            .expect("Spent vaults should not be empty");
+        let cpfp_script_pubkey = revaultd
+            .cpfp_descriptor
+            .derive(derivation_index, &revaultd.secp_ctx)
+            .into_inner()
+            .script_pubkey();
+        let deposit_address = revaultd
+            .deposit_descriptor
+            .derive(derivation_index, &revaultd.secp_ctx)
+            .into_inner()
+            .script_pubkey();
+        let mut cpfp_index = None;
+        let mut change_index = None;
+        for (i, txout) in db_spend.psbt.tx().output.iter().enumerate() {
+            if cpfp_index.is_none() && cpfp_script_pubkey == txout.script_pubkey {
+                cpfp_index = Some(i);
+            }
+
+            if deposit_address == txout.script_pubkey {
+                change_index = Some(i);
+            }
+        }
+
+        listspend_entries.push(ListSpendEntry {
+            psbt: db_spend.psbt,
+            deposit_outpoints,
+            cpfp_index: cpfp_index.expect("We always create a CPFP output"),
+            change_index,
+        });
+    }
+
+    Ok(listspend_entries)
+}
+
+/// Announce a Spend transaction to be used (after having optionally polled the cosigning servers),
+/// broadcast its corresponding Unvault transactions and register it for being broadcast it as soon
+/// as the timelock expires.
+/// If `priority` is set to `true`, we'll automatically try to feebump the Unvault and then the
+/// Spend transactions in the background if they don't confirm.
+///
+/// ## Errors
+/// - If `priority` is set to `true` and we don't have access to a CPFP private key
+/// - If the txid doesn't refer to a known Spend (must be stored using `updatespendtx` first)
+/// - If the Spend PSBT doesn't contain enough signatures, or contain invalid ones
+/// - If the Spend is too large to be announced
+pub fn set_spend_tx(
+    revaultd: &RevaultD,
+    bitcoind: &impl BitcoindThread,
+    spend_txid: &Txid,
+    priority: bool,
+) -> Result<(), CommandError> {
+    manager_only!(revaultd);
+    let db_path = revaultd.db_file();
+
+    if priority && revaultd.cpfp_key.is_none() {
+        return Err(CommandError::MissingCpfpKey);
+    }
+
+    // Get the referenced Spend and the vaults it spends from the DB
+    let mut spend_tx = db_spend_transaction(&db_path, &spend_txid)
+        .expect("Database must be available")
+        .ok_or_else(|| CommandError::UnknownSpend(*spend_txid))?;
+    let spent_vaults =
+        db_vaults_from_spend(&db_path, &spend_txid).expect("Database must be available");
+    let tx = &spend_tx.psbt.tx();
+    if spent_vaults.len() < tx.input.len() {
+        return Err(CommandError::SpendSpent(*spend_txid));
+    }
+
+    // Sanity check the Spend transaction is actually valid before announcing
+    // it. revault_tx already implements the signature checks so don't duplicate
+    // the logic and re-add the signatures to the PSBT.
+    let signatures: Vec<BTreeMap<BitcoinPubKey, Vec<u8>>> = spend_tx
+        .psbt
+        .psbt()
+        .inputs
+        .iter()
+        .map(|i| i.partial_sigs.clone())
+        .collect();
+    let mans_thresh = revaultd.managers_threshold();
+    for (i, sigmap) in signatures.iter().enumerate() {
+        if sigmap.len() < mans_thresh {
+            return Err(CommandError::SpendNotEnoughSig(sigmap.len(), mans_thresh));
+        }
+        for (pubkey, raw_sig) in sigmap {
+            let sig = secp256k1::Signature::from_der(&raw_sig[..raw_sig.len() - 1])
+                .map_err(|_| CommandError::SpendInvalidSig(raw_sig.clone()))?;
+            spend_tx
+                .psbt
+                .add_signature(i, pubkey.key, sig, &revaultd.secp_ctx)
+                .map_err(|_| CommandError::SpendInvalidSig(raw_sig.clone()))?
+                .expect("The signature was already there");
+        }
+    }
+
+    // FIXME: shouldn't `updatespendtx` make sure this doesn't happen??
+    // Check that we can actually send the tx to the coordinator...
+    if !check_spend_transaction_size(&revaultd, spend_tx.psbt.clone()) {
+        return Err(CommandError::SpendTooLarge);
+    };
+
+    // Now, if needed, we can ask all the cosigning servers for their
+    // signatures
+    let cosigs = revaultd.cosigs.as_ref().expect("We are manager");
+    if !cosigs.is_empty() {
+        log::debug!("Fetching signatures from Cosigning servers");
+        fetch_cosigs_signatures(
+            &revaultd.secp_ctx,
+            &revaultd.noise_secret,
+            &mut spend_tx.psbt,
+            cosigs,
+        )?;
+    }
+    let mut finalized_spend = spend_tx.psbt.clone();
+    finalized_spend.finalize(&revaultd.secp_ctx)?;
+
+    // And then announce it to the Coordinator
+    let deposit_outpoints: Vec<_> = spent_vaults
+        .values()
+        .map(|db_vault| db_vault.deposit_outpoint)
+        .collect();
+    announce_spend_transaction(
+        revaultd.coordinator_host,
+        &revaultd.noise_secret,
+        &revaultd.coordinator_noisekey,
+        finalized_spend,
+        deposit_outpoints,
+    )?;
+    db_update_spend(&db_path, &spend_tx.psbt, priority).expect("Database must be available");
+
+    // Finally we can broadcast the Unvault(s) transaction(s) and store the Spend
+    // transaction for later broadcast
+    log::debug!(
+        "Broadcasting Unvault transactions with ids '{:?}'",
+        spent_vaults.keys()
+    );
+    let bitcoin_txs = spent_vaults
+        .values()
+        .into_iter()
+        .map(|db_vault| {
+            let mut unvault_tx = db_unvault_transaction(&db_path, db_vault.id)
+                .expect("Database must be available")
+                .ok_or(CommandError::Race)?
+                .psbt
+                .assert_unvault();
+            unvault_tx.finalize(&revaultd.secp_ctx)?;
+            Ok(unvault_tx.into_psbt().extract_tx())
+        })
+        .collect::<Result<Vec<BitcoinTransaction>, CommandError>>()?;
+    bitcoind.broadcast(bitcoin_txs)?;
+    db_mark_broadcastable_spend(&db_path, spend_txid).expect("Database must be available");
+
+    Ok(())
+}
+
+/// Broadcast the Cancel transaction for an unvaulted vault.
+///
+/// ## Errors
+/// - If the outpoint doesn't refer to an existing, unvaulted (or unvaulting) vault
+/// - If the transaction broadcast fails for some reason
+pub fn revault(
+    revaultd: &RevaultD,
+    bitcoind: &impl BitcoindThread,
+    deposit_outpoint: &OutPoint,
+) -> Result<(), CommandError> {
+    let db_path = revaultd.db_file();
+
+    // Checking that the vault is secured, otherwise we don't have the cancel
+    // transaction
+    let vault = db_vault_by_deposit(&db_path, deposit_outpoint)
+        .expect("Database must be accessible")
+        .ok_or_else(|| CommandError::UnknownOutpoint(*deposit_outpoint))?;
+
+    if !matches!(
+        vault.status,
+        VaultStatus::Unvaulting | VaultStatus::Unvaulted | VaultStatus::Spending
+    ) {
+        return Err(CommandError::InvalidStatus(
+            vault.status,
+            VaultStatus::Unvaulting,
+        ));
+    }
+
+    let mut cancel_tx = db_cancel_transaction(&db_path, vault.id)
+        .expect("Database must be available")
+        .ok_or(CommandError::Race)?
+        .psbt
+        .assert_cancel();
+
+    cancel_tx.finalize(&revaultd.secp_ctx)?;
+    let transaction = cancel_tx.into_psbt().extract_tx();
+    log::debug!(
+        "Broadcasting Cancel transactions with id '{:?}'",
+        transaction.txid()
+    );
+    bitcoind.broadcast(vec![transaction])?;
+
+    Ok(())
+}
+
+/// Broadcast Emergency transactions for all existing vaults.
+///
+/// ## Errors
+/// - If called for a non-stakeholder
+pub fn emergency(revaultd: &RevaultD, bitcoind: &impl BitcoindThread) -> Result<(), CommandError> {
+    stakeholder_only!(revaultd);
+
+    // FIXME: there is a ton of edge cases not covered here. We should additionally opt for a
+    // bulk method, like broadcasting all Emergency transactions in a thread forever without
+    // trying to be smart by differentiating between Emer and UnvaultEmer until we die or all
+    // vaults are confirmed in the EDV.
+    let emers = finalized_emer_txs(&revaultd)?;
+    bitcoind.broadcast(emers)?;
+
+    Ok(())
+}
+
+/// Information about the configured servers.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServersStatuses {
+    coordinator: ServerStatus,
+    cosigners: Vec<ServerStatus>,
+    watchtowers: Vec<ServerStatus>,
+}
+
+/// Get information about all the configured servers.
+pub fn get_servers_statuses(revaultd: &RevaultD) -> ServersStatuses {
+    let coordinator = coordinator_status(&revaultd);
+    let cosigners = cosigners_status(&revaultd);
+    let watchtowers = watchtowers_status(&revaultd);
+
+    ServersStatuses {
+        coordinator,
+        cosigners,
+        watchtowers,
+    }
+}
+
+/// Get a paginated list of accounting events. This returns a maximum of `limit` events occuring
+/// between the dates `start` and `end`, filtered by kind of events.
+/// Aiming to give an accounting point of view, the amounts returned by this call are the total
+/// of inflows and outflows net of any change amount (that is technically a transaction output, but
+/// not a cash outflow).
+pub fn get_history(
+    revaultd: &RevaultD,
+    bitcoind: &impl BitcoindThread,
+    start: u32,
+    end: u32,
+    limit: u64,
+    kind: Vec<HistoryEventKind>,
+) -> Result<Vec<HistoryEvent>, CommandError> {
+    gethistory(revaultd, bitcoind, start, end, limit, kind)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -28,9 +28,9 @@ use crate::{
             db_vault_by_unvault_txid, db_vaults, db_vaults_from_spend, db_vaults_min_status,
         },
     },
-    revaultd::{BlockchainTip, RevaultD, VaultStatus},
+    revaultd::{BlockchainTip, VaultStatus},
     threadmessages::BitcoindThread,
-    VERSION,
+    DaemonControl, VERSION,
 };
 use utils::{
     finalized_emer_txs, gethistory, listvaults_from_db, presigned_txs, ser_amount, ser_to_string,
@@ -187,6 +187,1159 @@ macro_rules! manager_only {
     };
 }
 
+impl DaemonControl {
+    /// Get information about the current state of the daemon
+    pub fn getinfo(&self) -> GetInfoResult {
+        let revaultd = self.revaultd.read().unwrap();
+
+        // This means blockheight == 0 for IBD.
+        let BlockchainTip {
+            height: blockheight,
+            ..
+        } = db_tip(&revaultd.db_file()).expect("Database must not be dead");
+        let number_of_vaults = self
+            .listvaults(None, None)
+            .vaults
+            .iter()
+            .filter(|l| {
+                l.status != VaultStatus::Spent
+                    && l.status != VaultStatus::Canceled
+                    && l.status != VaultStatus::Unvaulted
+                    && l.status != VaultStatus::EmergencyVaulted
+            })
+            .count();
+
+        GetInfoResult {
+            version: VERSION.to_string(),
+            network: revaultd.bitcoind_config.network,
+            blockheight: blockheight as i32,
+            sync: self.bitcoind_conn.sync_progress(),
+            vaults: number_of_vaults,
+            managers_threshold: revaultd.managers_threshold(),
+            descriptors: GetInfoDescriptors {
+                deposit: revaultd.deposit_descriptor.clone(),
+                unvault: revaultd.unvault_descriptor.clone(),
+                cpfp: revaultd.cpfp_descriptor.clone(),
+            },
+        }
+    }
+
+    /// List the current vaults, optionally filtered by status and/or deposit outpoints.
+    pub fn listvaults(
+        &self,
+        statuses: Option<Vec<VaultStatus>>,
+        deposit_outpoints: Option<Vec<OutPoint>>,
+    ) -> ListVaultsResult {
+        let revaultd = self.revaultd.read().unwrap();
+        ListVaultsResult {
+            vaults: listvaults_from_db(&revaultd, statuses, deposit_outpoints)
+                .expect("Database must be available"),
+        }
+    }
+
+    /// Get the revocation transactions for the vault identified by this outpoint.
+    /// Returns None if there are no *confirmed* vault at this outpoint.
+    ///
+    /// ## Errors
+    /// - If called by a non-stakeholder
+    /// - If called for an unknown or unconfirmed vault
+    pub fn getrevocationtxs(
+        &self,
+        deposit_outpoint: OutPoint,
+    ) -> Result<RevocationTransactions, CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        stakeholder_only!(revaultd);
+        let db_path = &revaultd.db_file();
+
+        // First, make sure the vault exists and is confirmed.
+        let vault = db_vault_by_deposit(db_path, &deposit_outpoint)
+            .expect("Database must be available")
+            .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
+        if matches!(vault.status, VaultStatus::Unconfirmed) {
+            return Err(CommandError::InvalidStatus(
+                vault.status,
+                VaultStatus::Funded,
+            ));
+        };
+
+        let emer_address = revaultd
+            .emergency_address
+            .clone()
+            .expect("Must be stakeholder");
+        let (_, cancel_tx, emergency_tx, emergency_unvault_tx) = transaction_chain(
+            deposit_outpoint,
+            vault.amount,
+            &revaultd.deposit_descriptor,
+            &revaultd.unvault_descriptor,
+            &revaultd.cpfp_descriptor,
+            vault.derivation_index,
+            emer_address,
+            revaultd.lock_time,
+            &revaultd.secp_ctx,
+        )
+        .expect("We wouldn't have put a vault with an invalid chain in DB");
+
+        Ok(RevocationTransactions {
+            cancel_tx,
+            emergency_tx,
+            emergency_unvault_tx,
+        })
+    }
+
+    /// Set the signed revocation transactions for the vault at this outpoint.
+    ///
+    /// ## Errors
+    /// - If called for a non-stakeholder
+    /// - If called for an unknown or not 'funded' vault
+    /// - If given insane revocation txs PSBTs (without our signatures, with invalid sigs, ..)
+    pub fn revocationtxs(
+        &self,
+        deposit_outpoint: OutPoint,
+        cancel_tx: CancelTransaction,
+        emergency_tx: EmergencyTransaction,
+        unvault_emergency_tx: UnvaultEmergencyTransaction,
+    ) -> Result<(), CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        stakeholder_only!(revaultd);
+        let db_path = revaultd.db_file();
+        let secp_ctx = &revaultd.secp_ctx;
+
+        assert!(revaultd.is_stakeholder());
+
+        // They may only send revocation transactions for confirmed and not-yet-presigned
+        // vaults.
+        let db_vault = db_vault_by_deposit(&db_path, &deposit_outpoint)
+            .expect("Database must be available")
+            .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
+        if !matches!(db_vault.status, VaultStatus::Funded) {
+            return Err(CommandError::InvalidStatus(
+                db_vault.status,
+                VaultStatus::Funded,
+            ));
+        };
+
+        // Sanity check they didn't send us garbaged PSBTs
+        let mut cancel_db_tx = db_cancel_transaction(&db_path, db_vault.id)
+            .expect("The database must be available")
+            .ok_or(CommandError::Race)?;
+        let rpc_txid = cancel_tx.tx().wtxid();
+        let db_txid = cancel_db_tx.psbt.wtxid();
+        if rpc_txid != db_txid {
+            return Err(CommandError::InvalidParams(format!(
+                "Invalid Cancel tx: db wtxid is '{}' but this PSBT's is '{}' ",
+                db_txid, rpc_txid
+            )));
+        }
+        let mut emer_db_tx = db_emer_transaction(&revaultd.db_file(), db_vault.id)
+            .expect("The database must be available")
+            .ok_or(CommandError::Race)?;
+        let rpc_txid = emergency_tx.tx().wtxid();
+        let db_txid = emer_db_tx.psbt.wtxid();
+        if rpc_txid != db_txid {
+            return Err(CommandError::InvalidParams(format!(
+                "Invalid Emergency tx: db wtxid is '{}' but this PSBT's is '{}' ",
+                db_txid, rpc_txid
+            )));
+        }
+        let mut unvault_emer_db_tx = db_unvault_emer_transaction(&revaultd.db_file(), db_vault.id)
+            .expect("The database must be available")
+            .ok_or(CommandError::Race)?;
+        let rpc_txid = unvault_emergency_tx.tx().wtxid();
+        let db_txid = unvault_emer_db_tx.psbt.wtxid();
+        if rpc_txid != db_txid {
+            return Err(CommandError::InvalidParams(format!(
+                "Invalid Unvault Emergency tx: db wtxid is '{}' but this PSBT's is '{}' ",
+                db_txid, rpc_txid
+            )));
+        }
+
+        // Alias some vars we'll reuse
+        let deriv_index = db_vault.derivation_index;
+        let cancel_sigs = &cancel_tx
+            .psbt()
+            .inputs
+            .get(0)
+            .expect("Cancel tx has a single input, inbefore fee bumping.")
+            .partial_sigs;
+        let emer_sigs = &emergency_tx
+            .psbt()
+            .inputs
+            .get(0)
+            .expect("Emergency tx has a single input, inbefore fee bumping.")
+            .partial_sigs;
+        let unvault_emer_sigs = &unvault_emergency_tx
+            .psbt()
+            .inputs
+            .get(0)
+            .expect("UnvaultEmergency tx has a single input, inbefore fee bumping.")
+            .partial_sigs;
+
+        // They must have included *at least* a signature for our pubkey
+        let our_pubkey = revaultd
+            .our_stk_xpub_at(deriv_index)
+            .expect("We are a stakeholder, checked at the beginning of the call.");
+        if !cancel_sigs.contains_key(&our_pubkey) {
+            return Err(CommandError::InvalidParams(format!(
+                "No signature for ourselves ({}) in Cancel transaction",
+                our_pubkey
+            )));
+        }
+        // We use the same public key across the transaction chain, that's pretty
+        // neat from an usability perspective.
+        if !emer_sigs.contains_key(&our_pubkey) {
+            return Err(CommandError::InvalidParams(
+                "No signature for ourselves in Emergency transaction".to_string(),
+            ));
+        }
+        if !unvault_emer_sigs.contains_key(&our_pubkey) {
+            return Err(CommandError::InvalidParams(
+                "No signature for ourselves in UnvaultEmergency transaction".to_string(),
+            ));
+        }
+
+        // There is no reason for them to include an unnecessary signature, so be strict.
+        let stk_keys = revaultd.stakeholders_xpubs_at(deriv_index);
+        for (ref key, _) in cancel_sigs.iter() {
+            if !stk_keys.contains(key) {
+                return Err(CommandError::InvalidParams(format!(
+                    "Unknown key in Cancel transaction signatures: {}",
+                    key
+                )));
+            }
+        }
+        for (ref key, _) in emer_sigs.iter() {
+            if !stk_keys.contains(key) {
+                return Err(CommandError::InvalidParams(format!(
+                    "Unknown key in Emergency transaction signatures: {}",
+                    key
+                )));
+            }
+        }
+        for (ref key, _) in unvault_emer_sigs.iter() {
+            if !stk_keys.contains(key) {
+                return Err(CommandError::InvalidParams(format!(
+                    "Unknown key in UnvaultEmergency transaction signatures: {}",
+                    key
+                )));
+            }
+        }
+
+        // Add the signatures to the DB transactions.
+        for (key, sig) in cancel_sigs {
+            if sig.is_empty() {
+                return Err(CommandError::InvalidParams(format!(
+                    "Empty signature for key '{}' in Cancel PSBT",
+                    key
+                )));
+            }
+            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+                CommandError::InvalidParams(format!("Non DER signature in Cancel PSBT"))
+            })?;
+            cancel_db_tx
+                .psbt
+                .add_signature(key.key, sig, secp_ctx)
+                .map_err(|e| {
+                    CommandError::InvalidParams(format!(
+                        "Invalid signature '{}' in Cancel PSBT: '{}'",
+                        sig, e
+                    ))
+                })?;
+        }
+        for (key, sig) in emer_sigs {
+            if sig.is_empty() {
+                return Err(CommandError::InvalidParams(format!(
+                    "Empty signature for key '{}' in Emergency PSBT",
+                    key
+                )));
+            }
+            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+                CommandError::InvalidParams(format!("Non DER signature in Emergency PSBT"))
+            })?;
+            emer_db_tx
+                .psbt
+                .add_signature(key.key, sig, secp_ctx)
+                .map_err(|e| {
+                    CommandError::InvalidParams(format!(
+                        "Invalid signature '{}' in Emergency PSBT: '{}'",
+                        sig, e
+                    ))
+                })?;
+        }
+        for (key, sig) in unvault_emer_sigs {
+            if sig.is_empty() {
+                return Err(CommandError::InvalidParams(format!(
+                    "Empty signature for key '{}' in UnvaultEmergency PSBT",
+                    key
+                )));
+            }
+            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+                CommandError::InvalidParams(format!("Non DER signature in UnvaultEmergency PSBT",))
+            })?;
+            unvault_emer_db_tx
+                .psbt
+                .add_signature(key.key, sig, secp_ctx)
+                .map_err(|e| {
+                    CommandError::InvalidParams(format!(
+                        "Invalid signature '{}' in UnvaultEmergency PSBT: '{}'",
+                        sig, e
+                    ))
+                })?;
+        }
+
+        // Then add them to the PSBTs in database. Take care to update the vault
+        // status if all signatures were given via the RPC.
+        let rev_txs = vec![cancel_db_tx, emer_db_tx, unvault_emer_db_tx];
+        db_update_presigned_txs(&db_path, &db_vault, rev_txs.clone(), secp_ctx)
+            .expect("The database must be available");
+        db_mark_securing_vault(&db_path, db_vault.id).expect("The database must be available");
+
+        // If this made the Emergency fully signed and we are a stakeholder, share
+        // it with our watchtowers.
+        let emer_db_tx = db_emer_transaction(&db_path, db_vault.id)
+            .expect("The database must be available")
+            .ok_or(CommandError::Race)?;
+        if !db_vault.emer_shared && emer_db_tx.psbt.unwrap_emer().is_finalizable(secp_ctx) {
+            if let Some(ref watchtowers) = revaultd.watchtowers {
+                wts_share_emer_signatures(
+                    &revaultd.noise_secret,
+                    &watchtowers,
+                    db_vault.deposit_outpoint,
+                    db_vault.derivation_index,
+                    &emer_db_tx,
+                )?;
+            }
+        }
+        db_update_vault_status(&db_path, &db_vault).expect("The database must be available");
+
+        // Share them with our felow stakeholders.
+        coord_share_rev_signatures(
+            revaultd.coordinator_host,
+            &revaultd.noise_secret,
+            &revaultd.coordinator_noisekey,
+            &rev_txs,
+        )?;
+
+        Ok(())
+    }
+
+    /// Get the unvault transaction for the vault identified by this outpoint.
+    /// Returns None if there are no *confirmed* vault at this outpoint.
+    ///
+    /// ## Errors
+    /// - If called for a non stakeholder
+    /// - If called for an unknown or not 'funded' vault
+    pub fn get_unvault_tx(
+        &self,
+        deposit_outpoint: OutPoint,
+    ) -> Result<UnvaultTransaction, CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        stakeholder_only!(revaultd);
+        let db_path = &revaultd.db_file();
+        assert!(revaultd.is_stakeholder());
+
+        // We allow the call for Funded 'only' as unvaulttx would later fail if it's
+        // not 'secured'.
+        let vault = db_vault_by_deposit(db_path, &deposit_outpoint)
+            .expect("The database must be available")
+            .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
+        if matches!(vault.status, VaultStatus::Unconfirmed) {
+            return Err(CommandError::InvalidStatus(
+                vault.status,
+                VaultStatus::Funded,
+            ));
+        }
+
+        // Derive the descriptors needed to create the UnvaultTransaction
+        let deposit_descriptor = revaultd
+            .deposit_descriptor
+            .derive(vault.derivation_index, &revaultd.secp_ctx);
+        let deposit_txin = DepositTxIn::new(
+            deposit_outpoint,
+            DepositTxOut::new(vault.amount, &deposit_descriptor),
+        );
+        let unvault_descriptor = revaultd
+            .unvault_descriptor
+            .derive(vault.derivation_index, &revaultd.secp_ctx);
+        let cpfp_descriptor = revaultd
+            .cpfp_descriptor
+            .derive(vault.derivation_index, &revaultd.secp_ctx);
+
+        Ok(UnvaultTransaction::new(
+            deposit_txin,
+            &unvault_descriptor,
+            &cpfp_descriptor,
+            revaultd.lock_time,
+        )
+        .expect("We wouldn't have a vault with an invalid Unvault in DB"))
+    }
+
+    /// Set the signed unvault transaction for the vault at this outpoint.
+    ///
+    /// ## Errors
+    /// - If called for a non-stakeholder
+    /// - If called for an unknown or not 'secured' vault
+    /// - If passed an insane Unvault transaction (no sig for ourselves, invalid sig, ..)
+    pub fn set_unvault_tx(
+        &self,
+        deposit_outpoint: OutPoint,
+        unvault_tx: UnvaultTransaction,
+    ) -> Result<(), CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        stakeholder_only!(revaultd);
+        let db_path = revaultd.db_file();
+        let secp_ctx = &revaultd.secp_ctx;
+
+        // If they haven't got all the signatures for the revocation transactions, we'd
+        // better not send our unvault sig!
+        // If the vault is already active (or more) there is no point in spamming the
+        // coordinator.
+        let db_vault = db_vault_by_deposit(&db_path, &deposit_outpoint)
+            .expect("The database must be available")
+            .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
+        if !matches!(db_vault.status, VaultStatus::Secured) {
+            return Err(CommandError::InvalidStatus(
+                db_vault.status,
+                VaultStatus::Secured,
+            ));
+        }
+
+        // Sanity check they didn't send us a garbaged PSBT
+        let mut unvault_db_tx = db_unvault_transaction(&db_path, db_vault.id)
+            .expect("The database must be available")
+            .ok_or(CommandError::Race)?;
+        let rpc_txid = unvault_tx.tx().wtxid();
+        let db_txid = unvault_db_tx.psbt.wtxid();
+        if rpc_txid != db_txid {
+            return Err(CommandError::InvalidParams(format!(
+                "Invalid Unvault tx: db wtxid is '{}' but this PSBT's is '{}' ",
+                db_txid, rpc_txid
+            )));
+        }
+
+        let sigs = &unvault_tx
+            .psbt()
+            .inputs
+            .get(0)
+            .expect("UnvaultTransaction always has 1 input")
+            .partial_sigs;
+        let stk_keys = revaultd.stakeholders_xpubs_at(db_vault.derivation_index);
+        let our_key = revaultd
+            .our_stk_xpub_at(db_vault.derivation_index)
+            .expect("We are a stakeholder, checked at the beginning.");
+        // They must have included *at least* a signature for our pubkey, and must not include an
+        // unnecessary signature.
+        if !sigs.contains_key(&our_key) {
+            return Err(CommandError::InvalidParams(format!(
+                "No signature for ourselves ({}) in Unvault transaction",
+                our_key
+            )));
+        }
+
+        for (key, sig) in sigs {
+            // There is no reason for them to include an unnecessary signature, so be strict.
+            if !stk_keys.contains(&key) {
+                return Err(CommandError::InvalidParams(format!(
+                    "Unknown key in Unvault transaction signatures: {}",
+                    key
+                )));
+            }
+
+            if sig.is_empty() {
+                return Err(CommandError::InvalidParams(format!(
+                    "Empty signature for key '{}' in Unvault PSBT",
+                    key
+                )));
+            }
+            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
+                CommandError::InvalidParams(format!("Non DER signature in Unvault PSBT"))
+            })?;
+
+            unvault_db_tx
+                .psbt
+                .add_signature(key.key, sig, secp_ctx)
+                .map_err(|e| {
+                    CommandError::InvalidParams(format!(
+                        "Invalid signature '{}' in Unvault PSBT: '{}'",
+                        sig, e
+                    ))
+                })?;
+        }
+
+        // The watchtower(s) MUST have our second-stage (UnvaultEmer, Cancel) signatures
+        // before we share the Unvault one.
+        if let Some(ref watchtowers) = revaultd.watchtowers {
+            let unemer_db_tx = db_unvault_emer_transaction(&db_path, db_vault.id)
+                .expect("The database must be available")
+                .ok_or(CommandError::Race)?;
+            let cancel_db_tx = db_cancel_transaction(&db_path, db_vault.id)
+                .expect("The database must be available")
+                .ok_or(CommandError::Race)?;
+            wts_share_second_stage_signatures(
+                &revaultd.noise_secret,
+                &watchtowers,
+                db_vault.deposit_outpoint,
+                db_vault.derivation_index,
+                &cancel_db_tx,
+                &unemer_db_tx,
+            )?;
+        }
+
+        // Sanity checks passed. Store it then share it.
+        db_update_presigned_txs(&db_path, &db_vault, vec![unvault_db_tx.clone()], secp_ctx)
+            .expect("The database must be available");
+        db_mark_activating_vault(&db_path, db_vault.id).expect("The database must be available");
+        db_update_vault_status(&db_path, &db_vault).expect("The database must be available");
+        share_unvault_signatures(
+            revaultd.coordinator_host,
+            &revaultd.noise_secret,
+            &revaultd.coordinator_noisekey,
+            &unvault_db_tx,
+        )?;
+
+        Ok(())
+    }
+
+    /// List the presigned transactions for the vaults at these outpoints. If `outpoints` is empty,
+    /// list the presigned transactions for all vaults.
+    ///
+    /// # Errors
+    /// - If an outpoint does not refer to a known deposit, or if the status of the vault is
+    /// part of `invalid_statuses`.
+    pub fn presigned_transactions(
+        &self,
+        outpoints: &[OutPoint],
+    ) -> Result<Vec<ListPresignedTxEntry>, CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        let db_path = revaultd.db_file();
+        let db_vaults = if outpoints.is_empty() {
+            db_vaults_min_status(&db_path, VaultStatus::Funded).expect("Database must be available")
+        } else {
+            vaults_from_deposits(&db_path, &outpoints, &[VaultStatus::Unconfirmed])?
+        };
+
+        presigned_txs(&revaultd, db_vaults).ok_or(CommandError::Race)
+    }
+
+    /// List the onchain transactions for the vaults at these outpoints. If `outpoints` is empty, list
+    /// the onchain transactions for all vaults.
+    ///
+    /// # Errors
+    /// - If an outpoint does not refer to a known deposit, or if the status of the vault is
+    /// part of `invalid_statuses`.
+    pub fn onchain_transactions(
+        &self,
+        outpoints: &[OutPoint],
+    ) -> Result<Vec<ListOnchainTxEntry>, CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        let db_path = &revaultd.db_file();
+
+        let db_vaults = if outpoints.is_empty() {
+            db_vaults(&db_path).expect("Database must be available")
+        } else {
+            // We accept any status
+            vaults_from_deposits(&db_path, &outpoints, &[])?
+        };
+
+        let mut tx_list = Vec::with_capacity(db_vaults.len());
+        for db_vault in db_vaults {
+            let vault_outpoint = db_vault.deposit_outpoint;
+
+            // If the vault exist, there must always be a deposit transaction available.
+            let deposit = self
+                .bitcoind_conn
+                .wallet_tx(db_vault.deposit_outpoint.txid)?
+                .expect("Vault exists but not deposit tx?");
+
+            // For the other transactions, it depends on the status of the vault. For the sake of
+            // simplicity bitcoind will tell us (but we could have some optimisation eventually here,
+            // eg returning None early on Funded vaults).
+            let (unvault, cancel, emergency, unvault_emergency, spend) = match db_vault.status {
+                VaultStatus::Unvaulting | VaultStatus::Unvaulted => {
+                    let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
+                        .expect("Database must be available")
+                        .ok_or(CommandError::Race)?;
+                    let unvault = self.bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
+                    (unvault, None, None, None, None)
+                }
+                VaultStatus::Spending | VaultStatus::Spent => {
+                    let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
+                        .expect("Database must be available")
+                        .ok_or(CommandError::Race)?;
+                    let unvault = self.bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
+                    let spend = if let Some(spend_txid) = db_vault.final_txid {
+                        self.bitcoind_conn.wallet_tx(spend_txid)?
+                    } else {
+                        None
+                    };
+                    (unvault, None, None, None, spend)
+                }
+                VaultStatus::Canceling | VaultStatus::Canceled => {
+                    let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
+                        .expect("Database must be available")
+                        .ok_or(CommandError::Race)?;
+                    let unvault = self.bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
+                    let cancel = if let Some(cancel_txid) = db_vault.final_txid {
+                        self.bitcoind_conn.wallet_tx(cancel_txid)?
+                    } else {
+                        None
+                    };
+                    (unvault, cancel, None, None, None)
+                }
+                VaultStatus::EmergencyVaulting | VaultStatus::EmergencyVaulted => {
+                    // Emergencies are only for stakeholders!
+                    if revaultd.is_stakeholder() {
+                        let emer_db_tx = db_emer_transaction(db_path, db_vault.id)
+                            .expect("Database must be available")
+                            .ok_or(CommandError::Race)?;
+                        let emergency = self.bitcoind_conn.wallet_tx(emer_db_tx.psbt.txid())?;
+                        (None, None, emergency, None, None)
+                    } else {
+                        (None, None, None, None, None)
+                    }
+                }
+                VaultStatus::UnvaultEmergencyVaulting | VaultStatus::UnvaultEmergencyVaulted => {
+                    let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
+                        .expect("Database must be available")
+                        .ok_or(CommandError::Race)?;
+                    let unvault = self.bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
+
+                    // Emergencies are only for stakeholders!
+                    if revaultd.is_stakeholder() {
+                        let unemer_db_tx = db_emer_transaction(db_path, db_vault.id)
+                            .expect("Database must be available")
+                            .ok_or(CommandError::Race)?;
+                        let unvault_emergency =
+                            self.bitcoind_conn.wallet_tx(unemer_db_tx.psbt.txid())?;
+                        (unvault, None, None, unvault_emergency, None)
+                    } else {
+                        (unvault, None, None, None, None)
+                    }
+                }
+                // Other statuses do not have on chain transactions apart the deposit.
+                VaultStatus::Unconfirmed
+                | VaultStatus::Funded
+                | VaultStatus::Securing
+                | VaultStatus::Secured
+                | VaultStatus::Activating
+                | VaultStatus::Active => (None, None, None, None, None),
+            };
+
+            tx_list.push(ListOnchainTxEntry {
+                vault_outpoint,
+                deposit,
+                unvault,
+                cancel,
+                emergency,
+                unvault_emergency,
+                spend,
+            });
+        }
+
+        Ok(tx_list)
+    }
+
+    /// Create a Spend transaction for these deposit outpoints, paying to the specified addresses
+    /// at the given feerate (with a tolerance of 10% below it and any % above it if we can't create
+    /// a change output).
+    /// Mind we add a CPFP output, which must be taken into account by the feerate.
+    ///
+    /// # Errors
+    /// - If called for a non-manager
+    /// - If provided outpoints for unknown or not 'active' vaults
+    /// - If the Spend transaction creation fails (for instance due to too-high fees or dust outputs)
+    /// - If the created Spend transaction's feerate is more than 10% below the required feerate
+    /// - If the created Spend transaction is too large to be transmitted to the coordinator
+    pub fn get_spend_tx(
+        &self,
+        outpoints: &[OutPoint],
+        destinations: BTreeMap<Address, u64>,
+        feerate_vb: u64,
+    ) -> Result<SpendTransaction, CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        manager_only!(revaultd);
+        let db_file = &revaultd.db_file();
+
+        // FIXME: have a feerate type to avoid that
+        assert!(feerate_vb > 0, "Spend feerate can't be null.");
+
+        // Reconstruct the DepositTxin s from the outpoints and the vaults informations
+        let mut txins = Vec::with_capacity(outpoints.len());
+        // If we need a change output, use the highest derivation index of the vaults
+        // spent. This avoids leaking a new address needlessly while not introducing
+        // disrepancy between our indexes.
+        let mut change_index = bip32::ChildNumber::from(0);
+        for outpoint in outpoints {
+            let vault = db_vault_by_deposit(db_file, outpoint)
+                .expect("Database must be available")
+                .ok_or_else(|| CommandError::UnknownOutpoint(*outpoint))?;
+            if matches!(vault.status, VaultStatus::Active) {
+                if vault.derivation_index > change_index {
+                    change_index = vault.derivation_index;
+                }
+                txins.push((*outpoint, vault.amount, vault.derivation_index));
+            } else {
+                return Err(CommandError::InvalidStatus(
+                    vault.status,
+                    VaultStatus::Active,
+                ));
+            }
+        }
+
+        let txos: Vec<SpendTxOut> = destinations
+            .into_iter()
+            .map(|(addr, value)| {
+                let script_pubkey = addr.script_pubkey();
+                SpendTxOut::new(TxOut {
+                    value,
+                    script_pubkey,
+                })
+            })
+            .collect();
+
+        log::debug!(
+            "Creating a Spend transaction with deposit txins: '{:?}' and txos: '{:?}'",
+            &txins,
+            &txos
+        );
+
+        // This adds the CPFP output so create a dummy one to accurately compute the
+        // feerate.
+        let nochange_tx = spend_tx_from_deposits(
+            txins.clone(),
+            txos.clone(),
+            None, // No change :)
+            &revaultd.deposit_descriptor,
+            &revaultd.unvault_descriptor,
+            &revaultd.cpfp_descriptor,
+            revaultd.lock_time,
+            /* Deactivate insane feerate check */
+            false,
+            &revaultd.secp_ctx,
+        )
+        .map_err(|e| revault_tx::Error::from(e))?;
+
+        log::debug!(
+            "Spend tx without change: '{}'",
+            nochange_tx.as_psbt_string()
+        );
+
+        // If the feerate of the transaction would be much lower (< 90/100) than what they
+        // requested for, tell them.
+        let nochange_feerate_vb = nochange_tx
+            .max_feerate()
+            .checked_mul(4)
+            .expect("bug in feerate computation");
+        if nochange_feerate_vb * 10 < feerate_vb * 9 {
+            return Err(CommandError::SpendFeerateTooLow(
+                feerate_vb,
+                nochange_feerate_vb,
+            ));
+        }
+
+        // Add a change output if it would not be dust according to our standard (200k sats
+        // atm, see DUST_LIMIT).
+        // 8 (amount) + 1 (len) + 1 (v0) + 1 (push) + 32 (witscript hash)
+        const P2WSH_TXO_WEIGHT: u64 = 43 * 4;
+        let with_change_weight = nochange_tx
+            .max_weight()
+            .checked_add(P2WSH_TXO_WEIGHT)
+            .expect("weight computation bug");
+        let cur_fees = nochange_tx.fees();
+        let want_fees = with_change_weight
+            // Mental gymnastic: sat/vbyte to sat/wu rounded up
+            .checked_mul(feerate_vb + 3)
+            .map(|vbyte| vbyte.checked_div(4).unwrap());
+        let change_value = want_fees.map(|f| cur_fees.checked_sub(f)).flatten();
+        log::debug!(
+            "Weight with change: '{}'  --  Fees without change: '{}'  --  Wanted feerate: '{}'  \
+                    --  Wanted fees: '{:?}'  --  Change value: '{:?}'",
+            with_change_weight,
+            cur_fees,
+            feerate_vb,
+            want_fees,
+            change_value
+        );
+
+        let change_txo = change_value.and_then(|change_value| {
+            // The overhead incurred to the value of the CPFP output by the change output
+            // See https://github.com/revault/practical-revault/blob/master/transactions.md#spend_tx
+            let cpfp_overhead = 16 * P2WSH_TXO_WEIGHT;
+            if change_value > revault_tx::transactions::DUST_LIMIT + cpfp_overhead {
+                let change_txo = DepositTxOut::new(
+                    // arithmetic checked above
+                    Amount::from_sat(change_value - cpfp_overhead),
+                    &revaultd
+                        .deposit_descriptor
+                        .derive(change_index, &revaultd.secp_ctx),
+                );
+                log::debug!("Adding a change txo: '{:?}'", change_txo);
+                Some(change_txo)
+            } else {
+                None
+            }
+        });
+
+        // Now we can hand them the resulting transaction (sanity checked for insane fees).
+        let tx_res = spend_tx_from_deposits(
+            txins,
+            txos,
+            change_txo,
+            &revaultd.deposit_descriptor,
+            &revaultd.unvault_descriptor,
+            &revaultd.cpfp_descriptor,
+            revaultd.lock_time,
+            true,
+            &revaultd.secp_ctx,
+        )
+        .map_err(|e| revault_tx::Error::from(e))?;
+
+        if !check_spend_transaction_size(&revaultd, tx_res.clone()) {
+            return Err(CommandError::SpendTooLarge);
+        };
+        log::debug!("Final Spend transaction: '{:?}'", tx_res);
+
+        Ok(tx_res)
+    }
+
+    /// Store a new or update an existing Spend transaction in database.
+    ///
+    /// ## Errors
+    /// - If called for a non-manager
+    /// - If the given Spend transaction refers to an unknown Unvault txid
+    /// - If the Spend refers to an Unvault of a vault that isn't 'active'
+    pub fn update_spend_tx(&self, spend_tx: SpendTransaction) -> Result<(), CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        manager_only!(revaultd);
+        let db_path = revaultd.db_file();
+        let spend_txid = spend_tx.tx().txid();
+
+        // Fetch the Unvault it spends from the DB
+        let spend_inputs = &spend_tx.tx().input;
+        let mut db_unvaults = Vec::with_capacity(spend_inputs.len());
+        for txin in spend_inputs.iter() {
+            let (db_vault, db_unvault) =
+                db_vault_by_unvault_txid(&db_path, &txin.previous_output.txid)
+                    .expect("Database must be available")
+                    .ok_or_else(|| CommandError::SpendUnknownUnVault(txin.previous_output.txid))?;
+
+            if !matches!(db_vault.status, VaultStatus::Active) {
+                return Err(CommandError::InvalidStatus(
+                    db_vault.status,
+                    VaultStatus::Active,
+                ));
+            }
+
+            db_unvaults.push(db_unvault);
+        }
+
+        // The user has the ability to set priority to the transaction in
+        // setspendtx, here we always set it to false.
+        if db_spend_transaction(&db_path, &spend_txid)
+            .expect("Database must be available")
+            .is_some()
+        {
+            log::debug!("Updating Spend transaction '{}'", spend_txid);
+            db_update_spend(&db_path, &spend_tx, false).expect("Database must be available");
+        } else {
+            log::debug!("Storing new Spend transaction '{}'", spend_txid);
+            db_insert_spend(&db_path, &db_unvaults, &spend_tx).expect("Database must be available");
+        }
+
+        Ok(())
+    }
+
+    /// Delete a Spend transaction by txid.
+    /// **Note**: this does nothing if no Spend with this txid exist.
+    ///
+    /// ## Errors
+    /// - If called for a non-manager
+    pub fn del_spend_tx(&self, spend_txid: &Txid) -> Result<(), CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        manager_only!(revaultd);
+        let db_path = revaultd.db_file();
+        db_delete_spend(&db_path, spend_txid).expect("Database must be available");
+        Ok(())
+    }
+
+    /// List all Spend transaction, optionally curated by their status.
+    ///
+    /// ## Errors
+    /// - If called for a non-manager
+    pub fn list_spend_txs(
+        &self,
+        statuses: Option<&[ListSpendStatus]>,
+    ) -> Result<Vec<ListSpendEntry>, CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        manager_only!(revaultd);
+        let db_path = revaultd.db_file();
+
+        let spend_tx_map = db_list_spends(&db_path).expect("Database must be available");
+        let mut listspend_entries = Vec::with_capacity(spend_tx_map.len());
+        for (_, (db_spend, deposit_outpoints)) in spend_tx_map {
+            // Filter by status
+            if let Some(s) = &statuses {
+                let status = if let Some(true) = db_spend.broadcasted {
+                    ListSpendStatus::Broadcasted
+                } else if let Some(false) = db_spend.broadcasted {
+                    ListSpendStatus::Pending
+                } else {
+                    ListSpendStatus::NonFinal
+                };
+
+                if !s.contains(&status) {
+                    continue;
+                }
+            }
+
+            let spent_vaults = db_vaults_from_spend(&db_path, &db_spend.psbt.txid())
+                .expect("Database must be available");
+
+            let derivation_index = spent_vaults
+                .values()
+                .map(|v| v.derivation_index)
+                .max()
+                .expect("Spent vaults should not be empty");
+            let cpfp_script_pubkey = revaultd
+                .cpfp_descriptor
+                .derive(derivation_index, &revaultd.secp_ctx)
+                .into_inner()
+                .script_pubkey();
+            let deposit_address = revaultd
+                .deposit_descriptor
+                .derive(derivation_index, &revaultd.secp_ctx)
+                .into_inner()
+                .script_pubkey();
+            let mut cpfp_index = None;
+            let mut change_index = None;
+            for (i, txout) in db_spend.psbt.tx().output.iter().enumerate() {
+                if cpfp_index.is_none() && cpfp_script_pubkey == txout.script_pubkey {
+                    cpfp_index = Some(i);
+                }
+
+                if deposit_address == txout.script_pubkey {
+                    change_index = Some(i);
+                }
+            }
+
+            listspend_entries.push(ListSpendEntry {
+                psbt: db_spend.psbt,
+                deposit_outpoints,
+                cpfp_index: cpfp_index.expect("We always create a CPFP output"),
+                change_index,
+            });
+        }
+
+        Ok(listspend_entries)
+    }
+
+    /// Announce a Spend transaction to be used (after having optionally polled the cosigning servers),
+    /// broadcast its corresponding Unvault transactions and register it for being broadcast it as soon
+    /// as the timelock expires.
+    /// If `priority` is set to `true`, we'll automatically try to feebump the Unvault and then the
+    /// Spend transactions in the background if they don't confirm.
+    ///
+    /// ## Errors
+    /// - If `priority` is set to `true` and we don't have access to a CPFP private key
+    /// - If the txid doesn't refer to a known Spend (must be stored using `updatespendtx` first)
+    /// - If the Spend PSBT doesn't contain enough signatures, or contain invalid ones
+    /// - If the Spend is too large to be announced
+    pub fn set_spend_tx(&self, spend_txid: &Txid, priority: bool) -> Result<(), CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        manager_only!(revaultd);
+        let db_path = revaultd.db_file();
+
+        if priority && revaultd.cpfp_key.is_none() {
+            return Err(CommandError::MissingCpfpKey);
+        }
+
+        // Get the referenced Spend and the vaults it spends from the DB
+        let mut spend_tx = db_spend_transaction(&db_path, &spend_txid)
+            .expect("Database must be available")
+            .ok_or_else(|| CommandError::UnknownSpend(*spend_txid))?;
+        let spent_vaults =
+            db_vaults_from_spend(&db_path, &spend_txid).expect("Database must be available");
+        let tx = &spend_tx.psbt.tx();
+        if spent_vaults.len() < tx.input.len() {
+            return Err(CommandError::SpendSpent(*spend_txid));
+        }
+
+        // Sanity check the Spend transaction is actually valid before announcing
+        // it. revault_tx already implements the signature checks so don't duplicate
+        // the logic and re-add the signatures to the PSBT.
+        let signatures: Vec<BTreeMap<BitcoinPubKey, Vec<u8>>> = spend_tx
+            .psbt
+            .psbt()
+            .inputs
+            .iter()
+            .map(|i| i.partial_sigs.clone())
+            .collect();
+        let mans_thresh = revaultd.managers_threshold();
+        for (i, sigmap) in signatures.iter().enumerate() {
+            if sigmap.len() < mans_thresh {
+                return Err(CommandError::SpendNotEnoughSig(sigmap.len(), mans_thresh));
+            }
+            for (pubkey, raw_sig) in sigmap {
+                let sig = secp256k1::Signature::from_der(&raw_sig[..raw_sig.len() - 1])
+                    .map_err(|_| CommandError::SpendInvalidSig(raw_sig.clone()))?;
+                spend_tx
+                    .psbt
+                    .add_signature(i, pubkey.key, sig, &revaultd.secp_ctx)
+                    .map_err(|_| CommandError::SpendInvalidSig(raw_sig.clone()))?
+                    .expect("The signature was already there");
+            }
+        }
+
+        // FIXME: shouldn't `updatespendtx` make sure this doesn't happen??
+        // Check that we can actually send the tx to the coordinator...
+        if !check_spend_transaction_size(&revaultd, spend_tx.psbt.clone()) {
+            return Err(CommandError::SpendTooLarge);
+        };
+
+        // Now, if needed, we can ask all the cosigning servers for their
+        // signatures
+        let cosigs = revaultd.cosigs.as_ref().expect("We are manager");
+        if !cosigs.is_empty() {
+            log::debug!("Fetching signatures from Cosigning servers");
+            fetch_cosigs_signatures(
+                &revaultd.secp_ctx,
+                &revaultd.noise_secret,
+                &mut spend_tx.psbt,
+                cosigs,
+            )?;
+        }
+        let mut finalized_spend = spend_tx.psbt.clone();
+        finalized_spend.finalize(&revaultd.secp_ctx)?;
+
+        // And then announce it to the Coordinator
+        let deposit_outpoints: Vec<_> = spent_vaults
+            .values()
+            .map(|db_vault| db_vault.deposit_outpoint)
+            .collect();
+        announce_spend_transaction(
+            revaultd.coordinator_host,
+            &revaultd.noise_secret,
+            &revaultd.coordinator_noisekey,
+            finalized_spend,
+            deposit_outpoints,
+        )?;
+        db_update_spend(&db_path, &spend_tx.psbt, priority).expect("Database must be available");
+
+        // Finally we can broadcast the Unvault(s) transaction(s) and store the Spend
+        // transaction for later broadcast
+        log::debug!(
+            "Broadcasting Unvault transactions with ids '{:?}'",
+            spent_vaults.keys()
+        );
+        let bitcoin_txs = spent_vaults
+            .values()
+            .into_iter()
+            .map(|db_vault| {
+                let mut unvault_tx = db_unvault_transaction(&db_path, db_vault.id)
+                    .expect("Database must be available")
+                    .ok_or(CommandError::Race)?
+                    .psbt
+                    .assert_unvault();
+                unvault_tx.finalize(&revaultd.secp_ctx)?;
+                Ok(unvault_tx.into_psbt().extract_tx())
+            })
+            .collect::<Result<Vec<BitcoinTransaction>, CommandError>>()?;
+        self.bitcoind_conn.broadcast(bitcoin_txs)?;
+        db_mark_broadcastable_spend(&db_path, spend_txid).expect("Database must be available");
+
+        Ok(())
+    }
+
+    /// Broadcast the Cancel transaction for an unvaulted vault.
+    ///
+    /// ## Errors
+    /// - If the outpoint doesn't refer to an existing, unvaulted (or unvaulting) vault
+    /// - If the transaction broadcast fails for some reason
+    pub fn revault(&self, deposit_outpoint: &OutPoint) -> Result<(), CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        let db_path = revaultd.db_file();
+
+        // Checking that the vault is secured, otherwise we don't have the cancel
+        // transaction
+        let vault = db_vault_by_deposit(&db_path, deposit_outpoint)
+            .expect("Database must be accessible")
+            .ok_or_else(|| CommandError::UnknownOutpoint(*deposit_outpoint))?;
+
+        if !matches!(
+            vault.status,
+            VaultStatus::Unvaulting | VaultStatus::Unvaulted | VaultStatus::Spending
+        ) {
+            return Err(CommandError::InvalidStatus(
+                vault.status,
+                VaultStatus::Unvaulting,
+            ));
+        }
+
+        let mut cancel_tx = db_cancel_transaction(&db_path, vault.id)
+            .expect("Database must be available")
+            .ok_or(CommandError::Race)?
+            .psbt
+            .assert_cancel();
+
+        cancel_tx.finalize(&revaultd.secp_ctx)?;
+        let transaction = cancel_tx.into_psbt().extract_tx();
+        log::debug!(
+            "Broadcasting Cancel transactions with id '{:?}'",
+            transaction.txid()
+        );
+        self.bitcoind_conn.broadcast(vec![transaction])?;
+
+        Ok(())
+    }
+
+    /// Broadcast Emergency transactions for all existing vaults.
+    ///
+    /// ## Errors
+    /// - If called for a non-stakeholder
+    pub fn emergency(&self) -> Result<(), CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        stakeholder_only!(revaultd);
+
+        // FIXME: there is a ton of edge cases not covered here. We should additionally opt for a
+        // bulk method, like broadcasting all Emergency transactions in a thread forever without
+        // trying to be smart by differentiating between Emer and UnvaultEmer until we die or all
+        // vaults are confirmed in the EDV.
+        let emers = finalized_emer_txs(&revaultd)?;
+        self.bitcoind_conn.broadcast(emers)?;
+
+        Ok(())
+    }
+
+    /// Get information about all the configured servers.
+    pub fn get_servers_statuses(&self) -> ServersStatuses {
+        let revaultd = self.revaultd.read().unwrap();
+        let coordinator = coordinator_status(&revaultd);
+        let cosigners = cosigners_status(&revaultd);
+        let watchtowers = watchtowers_status(&revaultd);
+
+        ServersStatuses {
+            coordinator,
+            cosigners,
+            watchtowers,
+        }
+    }
+
+    /// Get a paginated list of accounting events. This returns a maximum of `limit` events occuring
+    /// between the dates `start` and `end`, filtered by kind of events.
+    /// Aiming to give an accounting point of view, the amounts returned by this call are the total
+    /// of inflows and outflows net of any change amount (that is technically a transaction output, but
+    /// not a cash outflow).
+    pub fn get_history(
+        &self,
+        start: u32,
+        end: u32,
+        limit: u64,
+        kind: Vec<HistoryEventKind>,
+    ) -> Result<Vec<HistoryEvent>, CommandError> {
+        let revaultd = self.revaultd.read().unwrap();
+        gethistory(&revaultd, &self.bitcoind_conn, start, end, limit, kind)
+    }
+}
+
 /// Descriptors the daemon was configured with
 #[derive(Debug, Clone, Serialize)]
 pub struct GetInfoDescriptors {
@@ -208,39 +1361,6 @@ pub struct GetInfoResult {
     pub vaults: usize,
     pub managers_threshold: usize,
     pub descriptors: GetInfoDescriptors,
-}
-
-/// Get information about the current state of the daemon
-pub fn getinfo(revaultd: &RevaultD, bitcoind: &impl BitcoindThread) -> GetInfoResult {
-    // This means blockheight == 0 for IBD.
-    let BlockchainTip {
-        height: blockheight,
-        ..
-    } = db_tip(&revaultd.db_file()).expect("Database must not be dead");
-    let number_of_vaults = listvaults(&revaultd, None, None)
-        .vaults
-        .iter()
-        .filter(|l| {
-            l.status != VaultStatus::Spent
-                && l.status != VaultStatus::Canceled
-                && l.status != VaultStatus::Unvaulted
-                && l.status != VaultStatus::EmergencyVaulted
-        })
-        .count();
-
-    GetInfoResult {
-        version: VERSION.to_string(),
-        network: revaultd.bitcoind_config.network,
-        blockheight: blockheight as i32,
-        sync: bitcoind.sync_progress(),
-        vaults: number_of_vaults,
-        managers_threshold: revaultd.managers_threshold(),
-        descriptors: GetInfoDescriptors {
-            deposit: revaultd.deposit_descriptor.clone(),
-            unvault: revaultd.unvault_descriptor.clone(),
-            cpfp: revaultd.cpfp_descriptor.clone(),
-        },
-    }
 }
 
 /// Information about a vault.
@@ -267,18 +1387,6 @@ pub struct ListVaultsResult {
     pub vaults: Vec<ListVaultsEntry>,
 }
 
-/// List the current vaults, optionally filtered by status and/or deposit outpoints.
-pub fn listvaults(
-    revaultd: &RevaultD,
-    statuses: Option<Vec<VaultStatus>>,
-    deposit_outpoints: Option<Vec<OutPoint>>,
-) -> ListVaultsResult {
-    ListVaultsResult {
-        vaults: listvaults_from_db(revaultd, statuses, deposit_outpoints)
-            .expect("Database must be available"),
-    }
-}
-
 /// Revocation transactions for a given vault
 #[derive(Debug, Clone, Serialize)]
 pub struct RevocationTransactions {
@@ -286,464 +1394,6 @@ pub struct RevocationTransactions {
     pub emergency_tx: EmergencyTransaction,
     // FIXME: consistent naming
     pub emergency_unvault_tx: UnvaultEmergencyTransaction,
-}
-
-/// Get the revocation transactions for the vault identified by this outpoint.
-/// Returns None if there are no *confirmed* vault at this outpoint.
-///
-/// ## Errors
-/// - If called by a non-stakeholder
-/// - If called for an unknown or unconfirmed vault
-pub fn getrevocationtxs(
-    revaultd: &RevaultD,
-    deposit_outpoint: OutPoint,
-) -> Result<RevocationTransactions, CommandError> {
-    stakeholder_only!(revaultd);
-    let db_path = &revaultd.db_file();
-
-    // First, make sure the vault exists and is confirmed.
-    let vault = db_vault_by_deposit(db_path, &deposit_outpoint)
-        .expect("Database must be available")
-        .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
-    if matches!(vault.status, VaultStatus::Unconfirmed) {
-        return Err(CommandError::InvalidStatus(
-            vault.status,
-            VaultStatus::Funded,
-        ));
-    };
-
-    let emer_address = revaultd
-        .emergency_address
-        .clone()
-        .expect("Must be stakeholder");
-    let (_, cancel_tx, emergency_tx, emergency_unvault_tx) = transaction_chain(
-        deposit_outpoint,
-        vault.amount,
-        &revaultd.deposit_descriptor,
-        &revaultd.unvault_descriptor,
-        &revaultd.cpfp_descriptor,
-        vault.derivation_index,
-        emer_address,
-        revaultd.lock_time,
-        &revaultd.secp_ctx,
-    )
-    .expect("We wouldn't have put a vault with an invalid chain in DB");
-
-    Ok(RevocationTransactions {
-        cancel_tx,
-        emergency_tx,
-        emergency_unvault_tx,
-    })
-}
-
-/// Set the signed revocation transactions for the vault at this outpoint.
-///
-/// ## Errors
-/// - If called for a non-stakeholder
-/// - If called for an unknown or not 'funded' vault
-/// - If given insane revocation txs PSBTs (without our signatures, with invalid sigs, ..)
-pub fn revocationtxs(
-    revaultd: &RevaultD,
-    deposit_outpoint: OutPoint,
-    cancel_tx: CancelTransaction,
-    emergency_tx: EmergencyTransaction,
-    unvault_emergency_tx: UnvaultEmergencyTransaction,
-) -> Result<(), CommandError> {
-    stakeholder_only!(revaultd);
-    let db_path = revaultd.db_file();
-    let secp_ctx = &revaultd.secp_ctx;
-
-    assert!(revaultd.is_stakeholder());
-
-    // They may only send revocation transactions for confirmed and not-yet-presigned
-    // vaults.
-    let db_vault = db_vault_by_deposit(&db_path, &deposit_outpoint)
-        .expect("Database must be available")
-        .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
-    if !matches!(db_vault.status, VaultStatus::Funded) {
-        return Err(CommandError::InvalidStatus(
-            db_vault.status,
-            VaultStatus::Funded,
-        ));
-    };
-
-    // Sanity check they didn't send us garbaged PSBTs
-    let mut cancel_db_tx = db_cancel_transaction(&db_path, db_vault.id)
-        .expect("The database must be available")
-        .ok_or(CommandError::Race)?;
-    let rpc_txid = cancel_tx.tx().wtxid();
-    let db_txid = cancel_db_tx.psbt.wtxid();
-    if rpc_txid != db_txid {
-        return Err(CommandError::InvalidParams(format!(
-            "Invalid Cancel tx: db wtxid is '{}' but this PSBT's is '{}' ",
-            db_txid, rpc_txid
-        )));
-    }
-    let mut emer_db_tx = db_emer_transaction(&revaultd.db_file(), db_vault.id)
-        .expect("The database must be available")
-        .ok_or(CommandError::Race)?;
-    let rpc_txid = emergency_tx.tx().wtxid();
-    let db_txid = emer_db_tx.psbt.wtxid();
-    if rpc_txid != db_txid {
-        return Err(CommandError::InvalidParams(format!(
-            "Invalid Emergency tx: db wtxid is '{}' but this PSBT's is '{}' ",
-            db_txid, rpc_txid
-        )));
-    }
-    let mut unvault_emer_db_tx = db_unvault_emer_transaction(&revaultd.db_file(), db_vault.id)
-        .expect("The database must be available")
-        .ok_or(CommandError::Race)?;
-    let rpc_txid = unvault_emergency_tx.tx().wtxid();
-    let db_txid = unvault_emer_db_tx.psbt.wtxid();
-    if rpc_txid != db_txid {
-        return Err(CommandError::InvalidParams(format!(
-            "Invalid Unvault Emergency tx: db wtxid is '{}' but this PSBT's is '{}' ",
-            db_txid, rpc_txid
-        )));
-    }
-
-    // Alias some vars we'll reuse
-    let deriv_index = db_vault.derivation_index;
-    let cancel_sigs = &cancel_tx
-        .psbt()
-        .inputs
-        .get(0)
-        .expect("Cancel tx has a single input, inbefore fee bumping.")
-        .partial_sigs;
-    let emer_sigs = &emergency_tx
-        .psbt()
-        .inputs
-        .get(0)
-        .expect("Emergency tx has a single input, inbefore fee bumping.")
-        .partial_sigs;
-    let unvault_emer_sigs = &unvault_emergency_tx
-        .psbt()
-        .inputs
-        .get(0)
-        .expect("UnvaultEmergency tx has a single input, inbefore fee bumping.")
-        .partial_sigs;
-
-    // They must have included *at least* a signature for our pubkey
-    let our_pubkey = revaultd
-        .our_stk_xpub_at(deriv_index)
-        .expect("We are a stakeholder, checked at the beginning of the call.");
-    if !cancel_sigs.contains_key(&our_pubkey) {
-        return Err(CommandError::InvalidParams(format!(
-            "No signature for ourselves ({}) in Cancel transaction",
-            our_pubkey
-        )));
-    }
-    // We use the same public key across the transaction chain, that's pretty
-    // neat from an usability perspective.
-    if !emer_sigs.contains_key(&our_pubkey) {
-        return Err(CommandError::InvalidParams(
-            "No signature for ourselves in Emergency transaction".to_string(),
-        ));
-    }
-    if !unvault_emer_sigs.contains_key(&our_pubkey) {
-        return Err(CommandError::InvalidParams(
-            "No signature for ourselves in UnvaultEmergency transaction".to_string(),
-        ));
-    }
-
-    // There is no reason for them to include an unnecessary signature, so be strict.
-    let stk_keys = revaultd.stakeholders_xpubs_at(deriv_index);
-    for (ref key, _) in cancel_sigs.iter() {
-        if !stk_keys.contains(key) {
-            return Err(CommandError::InvalidParams(format!(
-                "Unknown key in Cancel transaction signatures: {}",
-                key
-            )));
-        }
-    }
-    for (ref key, _) in emer_sigs.iter() {
-        if !stk_keys.contains(key) {
-            return Err(CommandError::InvalidParams(format!(
-                "Unknown key in Emergency transaction signatures: {}",
-                key
-            )));
-        }
-    }
-    for (ref key, _) in unvault_emer_sigs.iter() {
-        if !stk_keys.contains(key) {
-            return Err(CommandError::InvalidParams(format!(
-                "Unknown key in UnvaultEmergency transaction signatures: {}",
-                key
-            )));
-        }
-    }
-
-    // Add the signatures to the DB transactions.
-    for (key, sig) in cancel_sigs {
-        if sig.is_empty() {
-            return Err(CommandError::InvalidParams(format!(
-                "Empty signature for key '{}' in Cancel PSBT",
-                key
-            )));
-        }
-        let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
-            CommandError::InvalidParams(format!("Non DER signature in Cancel PSBT"))
-        })?;
-        cancel_db_tx
-            .psbt
-            .add_signature(key.key, sig, secp_ctx)
-            .map_err(|e| {
-                CommandError::InvalidParams(format!(
-                    "Invalid signature '{}' in Cancel PSBT: '{}'",
-                    sig, e
-                ))
-            })?;
-    }
-    for (key, sig) in emer_sigs {
-        if sig.is_empty() {
-            return Err(CommandError::InvalidParams(format!(
-                "Empty signature for key '{}' in Emergency PSBT",
-                key
-            )));
-        }
-        let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
-            CommandError::InvalidParams(format!("Non DER signature in Emergency PSBT"))
-        })?;
-        emer_db_tx
-            .psbt
-            .add_signature(key.key, sig, secp_ctx)
-            .map_err(|e| {
-                CommandError::InvalidParams(format!(
-                    "Invalid signature '{}' in Emergency PSBT: '{}'",
-                    sig, e
-                ))
-            })?;
-    }
-    for (key, sig) in unvault_emer_sigs {
-        if sig.is_empty() {
-            return Err(CommandError::InvalidParams(format!(
-                "Empty signature for key '{}' in UnvaultEmergency PSBT",
-                key
-            )));
-        }
-        let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
-            CommandError::InvalidParams(format!("Non DER signature in UnvaultEmergency PSBT",))
-        })?;
-        unvault_emer_db_tx
-            .psbt
-            .add_signature(key.key, sig, secp_ctx)
-            .map_err(|e| {
-                CommandError::InvalidParams(format!(
-                    "Invalid signature '{}' in UnvaultEmergency PSBT: '{}'",
-                    sig, e
-                ))
-            })?;
-    }
-
-    // Then add them to the PSBTs in database. Take care to update the vault
-    // status if all signatures were given via the RPC.
-    let rev_txs = vec![cancel_db_tx, emer_db_tx, unvault_emer_db_tx];
-    db_update_presigned_txs(&db_path, &db_vault, rev_txs.clone(), secp_ctx)
-        .expect("The database must be available");
-    db_mark_securing_vault(&db_path, db_vault.id).expect("The database must be available");
-
-    // If this made the Emergency fully signed and we are a stakeholder, share
-    // it with our watchtowers.
-    let emer_db_tx = db_emer_transaction(&db_path, db_vault.id)
-        .expect("The database must be available")
-        .ok_or(CommandError::Race)?;
-    if !db_vault.emer_shared && emer_db_tx.psbt.unwrap_emer().is_finalizable(secp_ctx) {
-        if let Some(ref watchtowers) = revaultd.watchtowers {
-            wts_share_emer_signatures(
-                &revaultd.noise_secret,
-                &watchtowers,
-                db_vault.deposit_outpoint,
-                db_vault.derivation_index,
-                &emer_db_tx,
-            )?;
-        }
-    }
-    db_update_vault_status(&db_path, &db_vault).expect("The database must be available");
-
-    // Share them with our felow stakeholders.
-    coord_share_rev_signatures(
-        revaultd.coordinator_host,
-        &revaultd.noise_secret,
-        &revaultd.coordinator_noisekey,
-        &rev_txs,
-    )?;
-
-    Ok(())
-}
-
-/// Get the unvault transaction for the vault identified by this outpoint.
-/// Returns None if there are no *confirmed* vault at this outpoint.
-///
-/// ## Errors
-/// - If called for a non stakeholder
-/// - If called for an unknown or not 'funded' vault
-pub fn get_unvault_tx(
-    revaultd: &RevaultD,
-    deposit_outpoint: OutPoint,
-) -> Result<UnvaultTransaction, CommandError> {
-    stakeholder_only!(revaultd);
-    let db_path = &revaultd.db_file();
-    assert!(revaultd.is_stakeholder());
-
-    // We allow the call for Funded 'only' as unvaulttx would later fail if it's
-    // not 'secured'.
-    let vault = db_vault_by_deposit(db_path, &deposit_outpoint)
-        .expect("The database must be available")
-        .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
-    if matches!(vault.status, VaultStatus::Unconfirmed) {
-        return Err(CommandError::InvalidStatus(
-            vault.status,
-            VaultStatus::Funded,
-        ));
-    }
-
-    // Derive the descriptors needed to create the UnvaultTransaction
-    let deposit_descriptor = revaultd
-        .deposit_descriptor
-        .derive(vault.derivation_index, &revaultd.secp_ctx);
-    let deposit_txin = DepositTxIn::new(
-        deposit_outpoint,
-        DepositTxOut::new(vault.amount, &deposit_descriptor),
-    );
-    let unvault_descriptor = revaultd
-        .unvault_descriptor
-        .derive(vault.derivation_index, &revaultd.secp_ctx);
-    let cpfp_descriptor = revaultd
-        .cpfp_descriptor
-        .derive(vault.derivation_index, &revaultd.secp_ctx);
-
-    Ok(UnvaultTransaction::new(
-        deposit_txin,
-        &unvault_descriptor,
-        &cpfp_descriptor,
-        revaultd.lock_time,
-    )
-    .expect("We wouldn't have a vault with an invalid Unvault in DB"))
-}
-
-/// Set the signed unvault transaction for the vault at this outpoint.
-///
-/// ## Errors
-/// - If called for a non-stakeholder
-/// - If called for an unknown or not 'secured' vault
-/// - If passed an insane Unvault transaction (no sig for ourselves, invalid sig, ..)
-pub fn set_unvault_tx(
-    revaultd: &RevaultD,
-    deposit_outpoint: OutPoint,
-    unvault_tx: UnvaultTransaction,
-) -> Result<(), CommandError> {
-    stakeholder_only!(revaultd);
-    let db_path = revaultd.db_file();
-    let secp_ctx = &revaultd.secp_ctx;
-
-    // If they haven't got all the signatures for the revocation transactions, we'd
-    // better not send our unvault sig!
-    // If the vault is already active (or more) there is no point in spamming the
-    // coordinator.
-    let db_vault = db_vault_by_deposit(&db_path, &deposit_outpoint)
-        .expect("The database must be available")
-        .ok_or_else(|| CommandError::UnknownOutpoint(deposit_outpoint))?;
-    if !matches!(db_vault.status, VaultStatus::Secured) {
-        return Err(CommandError::InvalidStatus(
-            db_vault.status,
-            VaultStatus::Secured,
-        ));
-    }
-
-    // Sanity check they didn't send us a garbaged PSBT
-    let mut unvault_db_tx = db_unvault_transaction(&db_path, db_vault.id)
-        .expect("The database must be available")
-        .ok_or(CommandError::Race)?;
-    let rpc_txid = unvault_tx.tx().wtxid();
-    let db_txid = unvault_db_tx.psbt.wtxid();
-    if rpc_txid != db_txid {
-        return Err(CommandError::InvalidParams(format!(
-            "Invalid Unvault tx: db wtxid is '{}' but this PSBT's is '{}' ",
-            db_txid, rpc_txid
-        )));
-    }
-
-    let sigs = &unvault_tx
-        .psbt()
-        .inputs
-        .get(0)
-        .expect("UnvaultTransaction always has 1 input")
-        .partial_sigs;
-    let stk_keys = revaultd.stakeholders_xpubs_at(db_vault.derivation_index);
-    let our_key = revaultd
-        .our_stk_xpub_at(db_vault.derivation_index)
-        .expect("We are a stakeholder, checked at the beginning.");
-    // They must have included *at least* a signature for our pubkey, and must not include an
-    // unnecessary signature.
-    if !sigs.contains_key(&our_key) {
-        return Err(CommandError::InvalidParams(format!(
-            "No signature for ourselves ({}) in Unvault transaction",
-            our_key
-        )));
-    }
-
-    for (key, sig) in sigs {
-        // There is no reason for them to include an unnecessary signature, so be strict.
-        if !stk_keys.contains(&key) {
-            return Err(CommandError::InvalidParams(format!(
-                "Unknown key in Unvault transaction signatures: {}",
-                key
-            )));
-        }
-
-        if sig.is_empty() {
-            return Err(CommandError::InvalidParams(format!(
-                "Empty signature for key '{}' in Unvault PSBT",
-                key
-            )));
-        }
-        let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
-            CommandError::InvalidParams(format!("Non DER signature in Unvault PSBT"))
-        })?;
-
-        unvault_db_tx
-            .psbt
-            .add_signature(key.key, sig, secp_ctx)
-            .map_err(|e| {
-                CommandError::InvalidParams(format!(
-                    "Invalid signature '{}' in Unvault PSBT: '{}'",
-                    sig, e
-                ))
-            })?;
-    }
-
-    // The watchtower(s) MUST have our second-stage (UnvaultEmer, Cancel) signatures
-    // before we share the Unvault one.
-    if let Some(ref watchtowers) = revaultd.watchtowers {
-        let unemer_db_tx = db_unvault_emer_transaction(&db_path, db_vault.id)
-            .expect("The database must be available")
-            .ok_or(CommandError::Race)?;
-        let cancel_db_tx = db_cancel_transaction(&db_path, db_vault.id)
-            .expect("The database must be available")
-            .ok_or(CommandError::Race)?;
-        wts_share_second_stage_signatures(
-            &revaultd.noise_secret,
-            &watchtowers,
-            db_vault.deposit_outpoint,
-            db_vault.derivation_index,
-            &cancel_db_tx,
-            &unemer_db_tx,
-        )?;
-    }
-
-    // Sanity checks passed. Store it then share it.
-    db_update_presigned_txs(&db_path, &db_vault, vec![unvault_db_tx.clone()], secp_ctx)
-        .expect("The database must be available");
-    db_mark_activating_vault(&db_path, db_vault.id).expect("The database must be available");
-    db_update_vault_status(&db_path, &db_vault).expect("The database must be available");
-    share_unvault_signatures(
-        revaultd.coordinator_host,
-        &revaultd.noise_secret,
-        &revaultd.coordinator_noisekey,
-        &unvault_db_tx,
-    )?;
-
-    Ok(())
 }
 
 /// A vault's presigned transaction.
@@ -767,26 +1417,6 @@ pub struct ListPresignedTxEntry {
     pub unvault_emergency: Option<VaultPresignedTransaction<UnvaultEmergencyTransaction>>,
 }
 
-/// List the presigned transactions for the vaults at these outpoints. If `outpoints` is empty,
-/// list the presigned transactions for all vaults.
-///
-/// # Errors
-/// - If an outpoint does not refer to a known deposit, or if the status of the vault is
-/// part of `invalid_statuses`.
-pub fn presigned_transactions(
-    revaultd: &RevaultD,
-    outpoints: &[OutPoint],
-) -> Result<Vec<ListPresignedTxEntry>, CommandError> {
-    let db_path = revaultd.db_file();
-    let db_vaults = if outpoints.is_empty() {
-        db_vaults_min_status(&db_path, VaultStatus::Funded).expect("Database must be available")
-    } else {
-        vaults_from_deposits(&db_path, &outpoints, &[VaultStatus::Unconfirmed])?
-    };
-
-    presigned_txs(&revaultd, db_vaults).ok_or(CommandError::Race)
-}
-
 /// Information about a vault's onchain transactions.
 #[derive(Debug, Clone, Serialize)]
 pub struct ListOnchainTxEntry {
@@ -799,344 +1429,6 @@ pub struct ListOnchainTxEntry {
     /// Always None if not stakeholder
     pub unvault_emergency: Option<WalletTransaction>,
     pub spend: Option<WalletTransaction>,
-}
-
-/// List the onchain transactions for the vaults at these outpoints. If `outpoints` is empty, list
-/// the onchain transactions for all vaults.
-///
-/// # Errors
-/// - If an outpoint does not refer to a known deposit, or if the status of the vault is
-/// part of `invalid_statuses`.
-pub fn onchain_transactions(
-    revaultd: &RevaultD,
-    bitcoind_conn: &impl BitcoindThread,
-    outpoints: &[OutPoint],
-) -> Result<Vec<ListOnchainTxEntry>, CommandError> {
-    let db_path = &revaultd.db_file();
-
-    let db_vaults = if outpoints.is_empty() {
-        db_vaults(&db_path).expect("Database must be available")
-    } else {
-        // We accept any status
-        vaults_from_deposits(&db_path, &outpoints, &[])?
-    };
-
-    let mut tx_list = Vec::with_capacity(db_vaults.len());
-    for db_vault in db_vaults {
-        let vault_outpoint = db_vault.deposit_outpoint;
-
-        // If the vault exist, there must always be a deposit transaction available.
-        let deposit = bitcoind_conn
-            .wallet_tx(db_vault.deposit_outpoint.txid)?
-            .expect("Vault exists but not deposit tx?");
-
-        // For the other transactions, it depends on the status of the vault. For the sake of
-        // simplicity bitcoind will tell us (but we could have some optimisation eventually here,
-        // eg returning None early on Funded vaults).
-        let (unvault, cancel, emergency, unvault_emergency, spend) = match db_vault.status {
-            VaultStatus::Unvaulting | VaultStatus::Unvaulted => {
-                let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
-                    .expect("Database must be available")
-                    .ok_or(CommandError::Race)?;
-                let unvault = bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
-                (unvault, None, None, None, None)
-            }
-            VaultStatus::Spending | VaultStatus::Spent => {
-                let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
-                    .expect("Database must be available")
-                    .ok_or(CommandError::Race)?;
-                let unvault = bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
-                let spend = if let Some(spend_txid) = db_vault.final_txid {
-                    bitcoind_conn.wallet_tx(spend_txid)?
-                } else {
-                    None
-                };
-                (unvault, None, None, None, spend)
-            }
-            VaultStatus::Canceling | VaultStatus::Canceled => {
-                let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
-                    .expect("Database must be available")
-                    .ok_or(CommandError::Race)?;
-                let unvault = bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
-                let cancel = if let Some(cancel_txid) = db_vault.final_txid {
-                    bitcoind_conn.wallet_tx(cancel_txid)?
-                } else {
-                    None
-                };
-                (unvault, cancel, None, None, None)
-            }
-            VaultStatus::EmergencyVaulting | VaultStatus::EmergencyVaulted => {
-                // Emergencies are only for stakeholders!
-                if revaultd.is_stakeholder() {
-                    let emer_db_tx = db_emer_transaction(db_path, db_vault.id)
-                        .expect("Database must be available")
-                        .ok_or(CommandError::Race)?;
-                    let emergency = bitcoind_conn.wallet_tx(emer_db_tx.psbt.txid())?;
-                    (None, None, emergency, None, None)
-                } else {
-                    (None, None, None, None, None)
-                }
-            }
-            VaultStatus::UnvaultEmergencyVaulting | VaultStatus::UnvaultEmergencyVaulted => {
-                let unvault_db_tx = db_unvault_transaction(db_path, db_vault.id)
-                    .expect("Database must be available")
-                    .ok_or(CommandError::Race)?;
-                let unvault = bitcoind_conn.wallet_tx(unvault_db_tx.psbt.txid())?;
-
-                // Emergencies are only for stakeholders!
-                if revaultd.is_stakeholder() {
-                    let unemer_db_tx = db_emer_transaction(db_path, db_vault.id)
-                        .expect("Database must be available")
-                        .ok_or(CommandError::Race)?;
-                    let unvault_emergency = bitcoind_conn.wallet_tx(unemer_db_tx.psbt.txid())?;
-                    (unvault, None, None, unvault_emergency, None)
-                } else {
-                    (unvault, None, None, None, None)
-                }
-            }
-            // Other statuses do not have on chain transactions apart the deposit.
-            VaultStatus::Unconfirmed
-            | VaultStatus::Funded
-            | VaultStatus::Securing
-            | VaultStatus::Secured
-            | VaultStatus::Activating
-            | VaultStatus::Active => (None, None, None, None, None),
-        };
-
-        tx_list.push(ListOnchainTxEntry {
-            vault_outpoint,
-            deposit,
-            unvault,
-            cancel,
-            emergency,
-            unvault_emergency,
-            spend,
-        });
-    }
-
-    Ok(tx_list)
-}
-
-/// Create a Spend transaction for these deposit outpoints, paying to the specified addresses
-/// at the given feerate (with a tolerance of 10% below it and any % above it if we can't create
-/// a change output).
-/// Mind we add a CPFP output, which must be taken into account by the feerate.
-///
-/// # Errors
-/// - If called for a non-manager
-/// - If provided outpoints for unknown or not 'active' vaults
-/// - If the Spend transaction creation fails (for instance due to too-high fees or dust outputs)
-/// - If the created Spend transaction's feerate is more than 10% below the required feerate
-/// - If the created Spend transaction is too large to be transmitted to the coordinator
-pub fn get_spend_tx(
-    revaultd: &RevaultD,
-    outpoints: &[OutPoint],
-    destinations: BTreeMap<Address, u64>,
-    feerate_vb: u64,
-) -> Result<SpendTransaction, CommandError> {
-    manager_only!(revaultd);
-    let db_file = &revaultd.db_file();
-
-    // FIXME: have a feerate type to avoid that
-    assert!(feerate_vb > 0, "Spend feerate can't be null.");
-
-    // Reconstruct the DepositTxin s from the outpoints and the vaults informations
-    let mut txins = Vec::with_capacity(outpoints.len());
-    // If we need a change output, use the highest derivation index of the vaults
-    // spent. This avoids leaking a new address needlessly while not introducing
-    // disrepancy between our indexes.
-    let mut change_index = bip32::ChildNumber::from(0);
-    for outpoint in outpoints {
-        let vault = db_vault_by_deposit(db_file, outpoint)
-            .expect("Database must be available")
-            .ok_or_else(|| CommandError::UnknownOutpoint(*outpoint))?;
-        if matches!(vault.status, VaultStatus::Active) {
-            if vault.derivation_index > change_index {
-                change_index = vault.derivation_index;
-            }
-            txins.push((*outpoint, vault.amount, vault.derivation_index));
-        } else {
-            return Err(CommandError::InvalidStatus(
-                vault.status,
-                VaultStatus::Active,
-            ));
-        }
-    }
-
-    let txos: Vec<SpendTxOut> = destinations
-        .into_iter()
-        .map(|(addr, value)| {
-            let script_pubkey = addr.script_pubkey();
-            SpendTxOut::new(TxOut {
-                value,
-                script_pubkey,
-            })
-        })
-        .collect();
-
-    log::debug!(
-        "Creating a Spend transaction with deposit txins: '{:?}' and txos: '{:?}'",
-        &txins,
-        &txos
-    );
-
-    // This adds the CPFP output so create a dummy one to accurately compute the
-    // feerate.
-    let nochange_tx = spend_tx_from_deposits(
-        txins.clone(),
-        txos.clone(),
-        None, // No change :)
-        &revaultd.deposit_descriptor,
-        &revaultd.unvault_descriptor,
-        &revaultd.cpfp_descriptor,
-        revaultd.lock_time,
-        /* Deactivate insane feerate check */
-        false,
-        &revaultd.secp_ctx,
-    )
-    .map_err(|e| revault_tx::Error::from(e))?;
-
-    log::debug!(
-        "Spend tx without change: '{}'",
-        nochange_tx.as_psbt_string()
-    );
-
-    // If the feerate of the transaction would be much lower (< 90/100) than what they
-    // requested for, tell them.
-    let nochange_feerate_vb = nochange_tx
-        .max_feerate()
-        .checked_mul(4)
-        .expect("bug in feerate computation");
-    if nochange_feerate_vb * 10 < feerate_vb * 9 {
-        return Err(CommandError::SpendFeerateTooLow(
-            feerate_vb,
-            nochange_feerate_vb,
-        ));
-    }
-
-    // Add a change output if it would not be dust according to our standard (200k sats
-    // atm, see DUST_LIMIT).
-    // 8 (amount) + 1 (len) + 1 (v0) + 1 (push) + 32 (witscript hash)
-    const P2WSH_TXO_WEIGHT: u64 = 43 * 4;
-    let with_change_weight = nochange_tx
-        .max_weight()
-        .checked_add(P2WSH_TXO_WEIGHT)
-        .expect("weight computation bug");
-    let cur_fees = nochange_tx.fees();
-    let want_fees = with_change_weight
-        // Mental gymnastic: sat/vbyte to sat/wu rounded up
-        .checked_mul(feerate_vb + 3)
-        .map(|vbyte| vbyte.checked_div(4).unwrap());
-    let change_value = want_fees.map(|f| cur_fees.checked_sub(f)).flatten();
-    log::debug!(
-        "Weight with change: '{}'  --  Fees without change: '{}'  --  Wanted feerate: '{}'  \
-                    --  Wanted fees: '{:?}'  --  Change value: '{:?}'",
-        with_change_weight,
-        cur_fees,
-        feerate_vb,
-        want_fees,
-        change_value
-    );
-
-    let change_txo = change_value.and_then(|change_value| {
-        // The overhead incurred to the value of the CPFP output by the change output
-        // See https://github.com/revault/practical-revault/blob/master/transactions.md#spend_tx
-        let cpfp_overhead = 16 * P2WSH_TXO_WEIGHT;
-        if change_value > revault_tx::transactions::DUST_LIMIT + cpfp_overhead {
-            let change_txo = DepositTxOut::new(
-                // arithmetic checked above
-                Amount::from_sat(change_value - cpfp_overhead),
-                &revaultd
-                    .deposit_descriptor
-                    .derive(change_index, &revaultd.secp_ctx),
-            );
-            log::debug!("Adding a change txo: '{:?}'", change_txo);
-            Some(change_txo)
-        } else {
-            None
-        }
-    });
-
-    // Now we can hand them the resulting transaction (sanity checked for insane fees).
-    let tx_res = spend_tx_from_deposits(
-        txins,
-        txos,
-        change_txo,
-        &revaultd.deposit_descriptor,
-        &revaultd.unvault_descriptor,
-        &revaultd.cpfp_descriptor,
-        revaultd.lock_time,
-        true,
-        &revaultd.secp_ctx,
-    )
-    .map_err(|e| revault_tx::Error::from(e))?;
-
-    if !check_spend_transaction_size(&revaultd, tx_res.clone()) {
-        return Err(CommandError::SpendTooLarge);
-    };
-    log::debug!("Final Spend transaction: '{:?}'", tx_res);
-
-    Ok(tx_res)
-}
-
-/// Store a new or update an existing Spend transaction in database.
-///
-/// ## Errors
-/// - If called for a non-manager
-/// - If the given Spend transaction refers to an unknown Unvault txid
-/// - If the Spend refers to an Unvault of a vault that isn't 'active'
-pub fn update_spend_tx(
-    revaultd: &RevaultD,
-    spend_tx: SpendTransaction,
-) -> Result<(), CommandError> {
-    manager_only!(revaultd);
-    let db_path = revaultd.db_file();
-    let spend_txid = spend_tx.tx().txid();
-
-    // Fetch the Unvault it spends from the DB
-    let spend_inputs = &spend_tx.tx().input;
-    let mut db_unvaults = Vec::with_capacity(spend_inputs.len());
-    for txin in spend_inputs.iter() {
-        let (db_vault, db_unvault) = db_vault_by_unvault_txid(&db_path, &txin.previous_output.txid)
-            .expect("Database must be available")
-            .ok_or_else(|| CommandError::SpendUnknownUnVault(txin.previous_output.txid))?;
-
-        if !matches!(db_vault.status, VaultStatus::Active) {
-            return Err(CommandError::InvalidStatus(
-                db_vault.status,
-                VaultStatus::Active,
-            ));
-        }
-
-        db_unvaults.push(db_unvault);
-    }
-
-    // The user has the ability to set priority to the transaction in
-    // setspendtx, here we always set it to false.
-    if db_spend_transaction(&db_path, &spend_txid)
-        .expect("Database must be available")
-        .is_some()
-    {
-        log::debug!("Updating Spend transaction '{}'", spend_txid);
-        db_update_spend(&db_path, &spend_tx, false).expect("Database must be available");
-    } else {
-        log::debug!("Storing new Spend transaction '{}'", spend_txid);
-        db_insert_spend(&db_path, &db_unvaults, &spend_tx).expect("Database must be available");
-    }
-
-    Ok(())
-}
-
-/// Delete a Spend transaction by txid.
-/// **Note**: this does nothing if no Spend with this txid exist.
-///
-/// ## Errors
-/// - If called for a non-manager
-pub fn del_spend_tx(revaultd: &RevaultD, spend_txid: &Txid) -> Result<(), CommandError> {
-    manager_only!(revaultd);
-    let db_path = revaultd.db_file();
-    db_delete_spend(&db_path, spend_txid).expect("Database must be available");
-    Ok(())
 }
 
 /// Status of a Spend transaction
@@ -1157,278 +1449,12 @@ pub struct ListSpendEntry {
     pub change_index: Option<usize>,
 }
 
-/// List all Spend transaction, optionally curated by their status.
-///
-/// ## Errors
-/// - If called for a non-manager
-pub fn list_spend_txs(
-    revaultd: &RevaultD,
-    statuses: Option<&[ListSpendStatus]>,
-) -> Result<Vec<ListSpendEntry>, CommandError> {
-    manager_only!(revaultd);
-    let db_path = revaultd.db_file();
-
-    let spend_tx_map = db_list_spends(&db_path).expect("Database must be available");
-    let mut listspend_entries = Vec::with_capacity(spend_tx_map.len());
-    for (_, (db_spend, deposit_outpoints)) in spend_tx_map {
-        // Filter by status
-        if let Some(s) = &statuses {
-            let status = if let Some(true) = db_spend.broadcasted {
-                ListSpendStatus::Broadcasted
-            } else if let Some(false) = db_spend.broadcasted {
-                ListSpendStatus::Pending
-            } else {
-                ListSpendStatus::NonFinal
-            };
-
-            if !s.contains(&status) {
-                continue;
-            }
-        }
-
-        let spent_vaults = db_vaults_from_spend(&db_path, &db_spend.psbt.txid())
-            .expect("Database must be available");
-
-        let derivation_index = spent_vaults
-            .values()
-            .map(|v| v.derivation_index)
-            .max()
-            .expect("Spent vaults should not be empty");
-        let cpfp_script_pubkey = revaultd
-            .cpfp_descriptor
-            .derive(derivation_index, &revaultd.secp_ctx)
-            .into_inner()
-            .script_pubkey();
-        let deposit_address = revaultd
-            .deposit_descriptor
-            .derive(derivation_index, &revaultd.secp_ctx)
-            .into_inner()
-            .script_pubkey();
-        let mut cpfp_index = None;
-        let mut change_index = None;
-        for (i, txout) in db_spend.psbt.tx().output.iter().enumerate() {
-            if cpfp_index.is_none() && cpfp_script_pubkey == txout.script_pubkey {
-                cpfp_index = Some(i);
-            }
-
-            if deposit_address == txout.script_pubkey {
-                change_index = Some(i);
-            }
-        }
-
-        listspend_entries.push(ListSpendEntry {
-            psbt: db_spend.psbt,
-            deposit_outpoints,
-            cpfp_index: cpfp_index.expect("We always create a CPFP output"),
-            change_index,
-        });
-    }
-
-    Ok(listspend_entries)
-}
-
-/// Announce a Spend transaction to be used (after having optionally polled the cosigning servers),
-/// broadcast its corresponding Unvault transactions and register it for being broadcast it as soon
-/// as the timelock expires.
-/// If `priority` is set to `true`, we'll automatically try to feebump the Unvault and then the
-/// Spend transactions in the background if they don't confirm.
-///
-/// ## Errors
-/// - If `priority` is set to `true` and we don't have access to a CPFP private key
-/// - If the txid doesn't refer to a known Spend (must be stored using `updatespendtx` first)
-/// - If the Spend PSBT doesn't contain enough signatures, or contain invalid ones
-/// - If the Spend is too large to be announced
-pub fn set_spend_tx(
-    revaultd: &RevaultD,
-    bitcoind: &impl BitcoindThread,
-    spend_txid: &Txid,
-    priority: bool,
-) -> Result<(), CommandError> {
-    manager_only!(revaultd);
-    let db_path = revaultd.db_file();
-
-    if priority && revaultd.cpfp_key.is_none() {
-        return Err(CommandError::MissingCpfpKey);
-    }
-
-    // Get the referenced Spend and the vaults it spends from the DB
-    let mut spend_tx = db_spend_transaction(&db_path, &spend_txid)
-        .expect("Database must be available")
-        .ok_or_else(|| CommandError::UnknownSpend(*spend_txid))?;
-    let spent_vaults =
-        db_vaults_from_spend(&db_path, &spend_txid).expect("Database must be available");
-    let tx = &spend_tx.psbt.tx();
-    if spent_vaults.len() < tx.input.len() {
-        return Err(CommandError::SpendSpent(*spend_txid));
-    }
-
-    // Sanity check the Spend transaction is actually valid before announcing
-    // it. revault_tx already implements the signature checks so don't duplicate
-    // the logic and re-add the signatures to the PSBT.
-    let signatures: Vec<BTreeMap<BitcoinPubKey, Vec<u8>>> = spend_tx
-        .psbt
-        .psbt()
-        .inputs
-        .iter()
-        .map(|i| i.partial_sigs.clone())
-        .collect();
-    let mans_thresh = revaultd.managers_threshold();
-    for (i, sigmap) in signatures.iter().enumerate() {
-        if sigmap.len() < mans_thresh {
-            return Err(CommandError::SpendNotEnoughSig(sigmap.len(), mans_thresh));
-        }
-        for (pubkey, raw_sig) in sigmap {
-            let sig = secp256k1::Signature::from_der(&raw_sig[..raw_sig.len() - 1])
-                .map_err(|_| CommandError::SpendInvalidSig(raw_sig.clone()))?;
-            spend_tx
-                .psbt
-                .add_signature(i, pubkey.key, sig, &revaultd.secp_ctx)
-                .map_err(|_| CommandError::SpendInvalidSig(raw_sig.clone()))?
-                .expect("The signature was already there");
-        }
-    }
-
-    // FIXME: shouldn't `updatespendtx` make sure this doesn't happen??
-    // Check that we can actually send the tx to the coordinator...
-    if !check_spend_transaction_size(&revaultd, spend_tx.psbt.clone()) {
-        return Err(CommandError::SpendTooLarge);
-    };
-
-    // Now, if needed, we can ask all the cosigning servers for their
-    // signatures
-    let cosigs = revaultd.cosigs.as_ref().expect("We are manager");
-    if !cosigs.is_empty() {
-        log::debug!("Fetching signatures from Cosigning servers");
-        fetch_cosigs_signatures(
-            &revaultd.secp_ctx,
-            &revaultd.noise_secret,
-            &mut spend_tx.psbt,
-            cosigs,
-        )?;
-    }
-    let mut finalized_spend = spend_tx.psbt.clone();
-    finalized_spend.finalize(&revaultd.secp_ctx)?;
-
-    // And then announce it to the Coordinator
-    let deposit_outpoints: Vec<_> = spent_vaults
-        .values()
-        .map(|db_vault| db_vault.deposit_outpoint)
-        .collect();
-    announce_spend_transaction(
-        revaultd.coordinator_host,
-        &revaultd.noise_secret,
-        &revaultd.coordinator_noisekey,
-        finalized_spend,
-        deposit_outpoints,
-    )?;
-    db_update_spend(&db_path, &spend_tx.psbt, priority).expect("Database must be available");
-
-    // Finally we can broadcast the Unvault(s) transaction(s) and store the Spend
-    // transaction for later broadcast
-    log::debug!(
-        "Broadcasting Unvault transactions with ids '{:?}'",
-        spent_vaults.keys()
-    );
-    let bitcoin_txs = spent_vaults
-        .values()
-        .into_iter()
-        .map(|db_vault| {
-            let mut unvault_tx = db_unvault_transaction(&db_path, db_vault.id)
-                .expect("Database must be available")
-                .ok_or(CommandError::Race)?
-                .psbt
-                .assert_unvault();
-            unvault_tx.finalize(&revaultd.secp_ctx)?;
-            Ok(unvault_tx.into_psbt().extract_tx())
-        })
-        .collect::<Result<Vec<BitcoinTransaction>, CommandError>>()?;
-    bitcoind.broadcast(bitcoin_txs)?;
-    db_mark_broadcastable_spend(&db_path, spend_txid).expect("Database must be available");
-
-    Ok(())
-}
-
-/// Broadcast the Cancel transaction for an unvaulted vault.
-///
-/// ## Errors
-/// - If the outpoint doesn't refer to an existing, unvaulted (or unvaulting) vault
-/// - If the transaction broadcast fails for some reason
-pub fn revault(
-    revaultd: &RevaultD,
-    bitcoind: &impl BitcoindThread,
-    deposit_outpoint: &OutPoint,
-) -> Result<(), CommandError> {
-    let db_path = revaultd.db_file();
-
-    // Checking that the vault is secured, otherwise we don't have the cancel
-    // transaction
-    let vault = db_vault_by_deposit(&db_path, deposit_outpoint)
-        .expect("Database must be accessible")
-        .ok_or_else(|| CommandError::UnknownOutpoint(*deposit_outpoint))?;
-
-    if !matches!(
-        vault.status,
-        VaultStatus::Unvaulting | VaultStatus::Unvaulted | VaultStatus::Spending
-    ) {
-        return Err(CommandError::InvalidStatus(
-            vault.status,
-            VaultStatus::Unvaulting,
-        ));
-    }
-
-    let mut cancel_tx = db_cancel_transaction(&db_path, vault.id)
-        .expect("Database must be available")
-        .ok_or(CommandError::Race)?
-        .psbt
-        .assert_cancel();
-
-    cancel_tx.finalize(&revaultd.secp_ctx)?;
-    let transaction = cancel_tx.into_psbt().extract_tx();
-    log::debug!(
-        "Broadcasting Cancel transactions with id '{:?}'",
-        transaction.txid()
-    );
-    bitcoind.broadcast(vec![transaction])?;
-
-    Ok(())
-}
-
-/// Broadcast Emergency transactions for all existing vaults.
-///
-/// ## Errors
-/// - If called for a non-stakeholder
-pub fn emergency(revaultd: &RevaultD, bitcoind: &impl BitcoindThread) -> Result<(), CommandError> {
-    stakeholder_only!(revaultd);
-
-    // FIXME: there is a ton of edge cases not covered here. We should additionally opt for a
-    // bulk method, like broadcasting all Emergency transactions in a thread forever without
-    // trying to be smart by differentiating between Emer and UnvaultEmer until we die or all
-    // vaults are confirmed in the EDV.
-    let emers = finalized_emer_txs(&revaultd)?;
-    bitcoind.broadcast(emers)?;
-
-    Ok(())
-}
-
 /// Information about the configured servers.
 #[derive(Debug, Clone, Serialize)]
 pub struct ServersStatuses {
     coordinator: ServerStatus,
     cosigners: Vec<ServerStatus>,
     watchtowers: Vec<ServerStatus>,
-}
-
-/// Get information about all the configured servers.
-pub fn get_servers_statuses(revaultd: &RevaultD) -> ServersStatuses {
-    let coordinator = coordinator_status(&revaultd);
-    let cosigners = cosigners_status(&revaultd);
-    let watchtowers = watchtowers_status(&revaultd);
-
-    ServersStatuses {
-        coordinator,
-        cosigners,
-        watchtowers,
-    }
 }
 
 /// The type of an accounting event.
@@ -1452,20 +1478,4 @@ pub struct HistoryEvent {
     pub fee: Option<u64>,
     pub txid: Txid,
     pub vaults: Vec<OutPoint>,
-}
-
-/// Get a paginated list of accounting events. This returns a maximum of `limit` events occuring
-/// between the dates `start` and `end`, filtered by kind of events.
-/// Aiming to give an accounting point of view, the amounts returned by this call are the total
-/// of inflows and outflows net of any change amount (that is technically a transaction output, but
-/// not a cash outflow).
-pub fn get_history(
-    revaultd: &RevaultD,
-    bitcoind: &impl BitcoindThread,
-    start: u32,
-    end: u32,
-    limit: u64,
-    kind: Vec<HistoryEventKind>,
-) -> Result<Vec<HistoryEvent>, CommandError> {
-    gethistory(revaultd, bitcoind, start, end, limit, kind)
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod utils;
 pub use crate::{
     bitcoind::{interface::WalletTransaction, BitcoindError},
     communication::ServerStatus,
+    revaultd::{BlockchainTip, VaultStatus},
 };
 use crate::{
     communication::{
@@ -28,7 +29,6 @@ use crate::{
             db_vault_by_unvault_txid, db_vaults, db_vaults_from_spend, db_vaults_min_status,
         },
     },
-    revaultd::{BlockchainTip, VaultStatus},
     threadmessages::BitcoindThread,
     DaemonControl, VERSION,
 };

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -237,6 +237,16 @@ impl DaemonControl {
         }
     }
 
+    /// Get the deposit address at the lowest still unused derivation index
+    pub fn get_deposit_address(&self) -> Address {
+        self.revaultd.read().unwrap().deposit_address()
+    }
+
+    // Internal only, used for testing
+    pub(crate) fn get_deposit_address_at(&self, index: bip32::ChildNumber) -> Address {
+        self.revaultd.read().unwrap().vault_address(index)
+    }
+
     /// Get the revocation transactions for the vault identified by this outpoint.
     /// Returns None if there are no *confirmed* vault at this outpoint.
     ///

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -189,7 +189,7 @@ macro_rules! manager_only {
 
 impl DaemonControl {
     /// Get information about the current state of the daemon
-    pub fn getinfo(&self) -> GetInfoResult {
+    pub fn get_info(&self) -> GetInfoResult {
         let revaultd = self.revaultd.read().unwrap();
 
         // This means blockheight == 0 for IBD.
@@ -198,7 +198,7 @@ impl DaemonControl {
             ..
         } = db_tip(&revaultd.db_file()).expect("Database must not be dead");
         let number_of_vaults = self
-            .listvaults(None, None)
+            .list_vaults(None, None)
             .vaults
             .iter()
             .filter(|l| {
@@ -225,7 +225,7 @@ impl DaemonControl {
     }
 
     /// List the current vaults, optionally filtered by status and/or deposit outpoints.
-    pub fn listvaults(
+    pub fn list_vaults(
         &self,
         statuses: Option<Vec<VaultStatus>>,
         deposit_outpoints: Option<Vec<OutPoint>>,
@@ -253,7 +253,7 @@ impl DaemonControl {
     /// ## Errors
     /// - If called by a non-stakeholder
     /// - If called for an unknown or unconfirmed vault
-    pub fn getrevocationtxs(
+    pub fn get_revocation_txs(
         &self,
         deposit_outpoint: OutPoint,
     ) -> Result<RevocationTransactions, CommandError> {
@@ -302,7 +302,7 @@ impl DaemonControl {
     /// - If called for a non-stakeholder
     /// - If called for an unknown or not 'funded' vault
     /// - If given insane revocation txs PSBTs (without our signatures, with invalid sigs, ..)
-    pub fn revocationtxs(
+    pub fn set_revocation_txs(
         &self,
         deposit_outpoint: OutPoint,
         cancel_tx: CancelTransaction,
@@ -715,7 +715,7 @@ impl DaemonControl {
     /// # Errors
     /// - If an outpoint does not refer to a known deposit, or if the status of the vault is
     /// part of `invalid_statuses`.
-    pub fn presigned_transactions(
+    pub fn list_presigned_txs(
         &self,
         outpoints: &[OutPoint],
     ) -> Result<Vec<ListPresignedTxEntry>, CommandError> {
@@ -736,7 +736,7 @@ impl DaemonControl {
     /// # Errors
     /// - If an outpoint does not refer to a known deposit, or if the status of the vault is
     /// part of `invalid_statuses`.
-    pub fn onchain_transactions(
+    pub fn list_onchain_txs(
         &self,
         outpoints: &[OutPoint],
     ) -> Result<Vec<ListOnchainTxEntry>, CommandError> {

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -472,10 +472,11 @@ mod tests {
             },
             schema::{DbTransaction, DbVault},
         },
-        jsonrpc::UserRole,
         revaultd::{RevaultD, VaultStatus},
         setup_db,
-        utils::test_utils::{dummy_revaultd, insert_vault_in_db, test_datadir, MockBitcoindThread},
+        utils::test_utils::{
+            dummy_revaultd, insert_vault_in_db, test_datadir, MockBitcoindThread, UserRole,
+        },
     };
     use revault_tx::{
         bitcoin::{

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -338,7 +338,7 @@ pub fn get_presigs(
     Ok(resp.signatures)
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ServerStatus {
     pub host: String,
     pub reachable: bool,

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -429,8 +429,7 @@ mod tests {
             bitcointx::{RevaultTx, TransactionType},
             schema::DbTransaction,
         },
-        jsonrpc::UserRole,
-        utils::test_utils::{dummy_revaultd, test_datadir},
+        utils::test_utils::{dummy_revaultd, test_datadir, UserRole},
     };
     use revault_net::{
         message, sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::gen_keypair,

--- a/src/database/actions.rs
+++ b/src/database/actions.rs
@@ -910,8 +910,7 @@ pub fn db_mark_rebroadcastable_spend(
 mod test {
     use super::*;
     use crate::database::schema::DbSpendTransaction;
-    use crate::jsonrpc::UserRole;
-    use crate::utils::test_utils::{dummy_revaultd, test_datadir};
+    use crate::utils::test_utils::{dummy_revaultd, test_datadir, UserRole};
     use revault_tx::{
         bitcoin::{
             Network, OutPoint, PrivateKey as BitcoinPrivKey, PublicKey as BitcoinPubKey,

--- a/src/database/interface.rs
+++ b/src/database/interface.rs
@@ -935,8 +935,7 @@ pub fn db_vaults_with_txids_in_period(
 mod test {
     use super::*;
     use crate::database::actions::{db_confirm_deposit, db_insert_new_unconfirmed_vault, setup_db};
-    use crate::jsonrpc::UserRole;
-    use crate::utils::test_utils::{dummy_revaultd, test_datadir};
+    use crate::utils::test_utils::{dummy_revaultd, test_datadir, UserRole};
     use revault_tx::{bitcoin::OutPoint, transactions::transaction_chain};
 
     use std::{fs, str::FromStr};

--- a/src/jsonrpc/api/error.rs
+++ b/src/jsonrpc/api/error.rs
@@ -1,6 +1,6 @@
 use crate::{
     bitcoind::BitcoindError, commands::CommandError, communication::CommunicationError,
-    control::RpcControlError, database::DatabaseError,
+    database::DatabaseError,
 };
 
 use std::sync::mpsc::{RecvError, SendError};
@@ -32,21 +32,6 @@ impl From<BitcoindError> for JsonRpcError {
 impl From<CommunicationError> for JsonRpcError {
     fn from(e: CommunicationError) -> JsonRpcError {
         Error::from(e).into()
-    }
-}
-
-impl From<RpcControlError> for Error {
-    fn from(e: RpcControlError) -> Error {
-        let code = match e {
-            RpcControlError::InvalidStatus(..) => ErrorCode::INVALID_STATUS_ERROR,
-            RpcControlError::UnknownOutPoint(_) => ErrorCode::RESOURCE_NOT_FOUND_ERROR,
-            RpcControlError::Database(_) => ErrorCode::INTERNAL_ERROR,
-            RpcControlError::Tx(_) => ErrorCode::INTERNAL_ERROR,
-            RpcControlError::Bitcoind(_) => ErrorCode::BITCOIND_ERROR,
-            RpcControlError::ThreadCommunication(_) => ErrorCode::INTERNAL_ERROR,
-            RpcControlError::TransactionNotFound => ErrorCode::INTERNAL_ERROR,
-        };
-        Error(code, e.to_string())
     }
 }
 

--- a/src/jsonrpc/api/mod.rs
+++ b/src/jsonrpc/api/mod.rs
@@ -227,7 +227,7 @@ impl RpcApi for RpcImpl {
     }
 
     fn getinfo(&self, meta: Self::Metadata) -> jsonrpc_core::Result<serde_json::Value> {
-        Ok(json!(meta.rpc_utils.getinfo()))
+        Ok(json!(meta.rpc_utils.get_info()))
     }
 
     fn help(&self, _: Self::Metadata) -> jsonrpc_core::Result<serde_json::Value> {
@@ -319,7 +319,7 @@ impl RpcApi for RpcImpl {
             None
         };
 
-        let res = meta.rpc_utils.listvaults(statuses, outpoints);
+        let res = meta.rpc_utils.list_vaults(statuses, outpoints);
         Ok(json!(res))
     }
 
@@ -341,7 +341,7 @@ impl RpcApi for RpcImpl {
         meta: Self::Metadata,
         outpoint: OutPoint,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        let res = meta.rpc_utils.getrevocationtxs(outpoint)?;
+        let res = meta.rpc_utils.get_revocation_txs(outpoint)?;
         Ok(json!(res))
     }
 
@@ -353,8 +353,12 @@ impl RpcApi for RpcImpl {
         emergency_tx: EmergencyTransaction,
         unvault_emergency_tx: UnvaultEmergencyTransaction,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        meta.rpc_utils
-            .revocationtxs(outpoint, cancel_tx, emergency_tx, unvault_emergency_tx)?;
+        meta.rpc_utils.set_revocation_txs(
+            outpoint,
+            cancel_tx,
+            emergency_tx,
+            unvault_emergency_tx,
+        )?;
         Ok(json!({}))
     }
 
@@ -386,7 +390,7 @@ impl RpcApi for RpcImpl {
     ) -> jsonrpc_core::Result<serde_json::Value> {
         let pres_txs = meta
             .rpc_utils
-            .presigned_transactions(&outpoints.as_deref().unwrap_or(&[]))?;
+            .list_presigned_txs(&outpoints.as_deref().unwrap_or(&[]))?;
         Ok(json!({ "presigned_transactions": pres_txs }))
     }
 
@@ -397,7 +401,7 @@ impl RpcApi for RpcImpl {
     ) -> jsonrpc_core::Result<serde_json::Value> {
         let txs = meta
             .rpc_utils
-            .onchain_transactions(&outpoints.as_deref().unwrap_or(&[]))?;
+            .list_onchain_txs(&outpoints.as_deref().unwrap_or(&[]))?;
         Ok(json!({
             "onchain_transactions": txs,
         }))

--- a/src/jsonrpc/api/mod.rs
+++ b/src/jsonrpc/api/mod.rs
@@ -3,7 +3,6 @@
 //! `server` mod.
 
 mod error;
-use error::Error;
 
 use crate::{
     commands::{
@@ -14,7 +13,7 @@ use crate::{
     },
     jsonrpc::{RpcUtils, UserRole},
     revaultd::VaultStatus,
-    threadmessages::{BitcoindThread, SigFetcherMessageOut},
+    threadmessages::{BitcoindThread, SigFetcherThread},
 };
 
 use revault_tx::{
@@ -233,10 +232,7 @@ impl RpcApi for RpcImpl {
         log::info!("Stopping revaultd");
 
         meta.rpc_utils.bitcoind_conn.shutdown();
-        meta.rpc_utils
-            .sigfetcher_tx
-            .send(SigFetcherMessageOut::Shutdown)
-            .map_err(Error::from)?;
+        meta.rpc_utils.sigfetcher_conn.shutdown();
         meta.shutdown();
 
         Ok(())

--- a/src/jsonrpc/api/mod.rs
+++ b/src/jsonrpc/api/mod.rs
@@ -10,10 +10,9 @@ use crate::{
         del_spend_tx, emergency, get_history, get_servers_statuses, get_spend_tx, get_unvault_tx,
         getinfo, getrevocationtxs, list_spend_txs, listvaults, onchain_transactions,
         presigned_transactions, revault, revocationtxs, set_spend_tx, set_unvault_tx,
-        update_spend_tx, ListSpendStatus,
+        update_spend_tx, HistoryEventKind, ListSpendStatus,
     },
-    control::{HistoryEventKind, RpcUtils},
-    jsonrpc::UserRole,
+    jsonrpc::{RpcUtils, UserRole},
     revaultd::VaultStatus,
     threadmessages::{BitcoindThread, SigFetcherMessageOut},
 };

--- a/src/jsonrpc/api/mod.rs
+++ b/src/jsonrpc/api/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         presigned_transactions, revault, revocationtxs, set_spend_tx, set_unvault_tx,
         update_spend_tx, HistoryEventKind, ListSpendStatus,
     },
-    jsonrpc::{RpcUtils, UserRole},
+    jsonrpc::RpcUtils,
     revaultd::VaultStatus,
     threadmessages::{BitcoindThread, SigFetcherThread},
 };
@@ -40,16 +40,14 @@ use serde_json::json;
 #[derive(Clone)]
 pub struct JsonRpcMetaData {
     pub shutdown: Arc<AtomicBool>,
-    pub role: UserRole,
     pub rpc_utils: RpcUtils,
 }
 impl jsonrpc_core::Metadata for JsonRpcMetaData {}
 
 impl JsonRpcMetaData {
-    pub fn new(role: UserRole, rpc_utils: RpcUtils) -> Self {
+    pub fn new(rpc_utils: RpcUtils) -> Self {
         JsonRpcMetaData {
             shutdown: Arc::from(AtomicBool::from(false)),
-            role,
             rpc_utils,
         }
     }

--- a/src/jsonrpc/api/mod.rs
+++ b/src/jsonrpc/api/mod.rs
@@ -5,48 +5,25 @@
 mod error;
 use error::Error;
 
-use crate::VERSION;
 use crate::{
-    bitcoind::interface::WalletTransaction,
-    communication::{
-        announce_spend_transaction, check_spend_transaction_size, coord_share_rev_signatures,
-        coordinator_status, cosigners_status, fetch_cosigs_signatures, share_unvault_signatures,
-        watchtowers_status, wts_share_emer_signatures, wts_share_second_stage_signatures,
+    commands::{
+        del_spend_tx, emergency, get_history, get_servers_statuses, get_spend_tx, get_unvault_tx,
+        getinfo, getrevocationtxs, list_spend_txs, listvaults, onchain_transactions,
+        presigned_transactions, revault, revocationtxs, set_spend_tx, set_unvault_tx,
+        update_spend_tx, ListSpendStatus,
     },
-    control::{
-        finalized_emer_txs, get_history, listvaults_from_db, onchain_txs, presigned_txs,
-        vaults_from_deposits, HistoryEventKind, ListSpendEntry, ListSpendStatus, RpcUtils,
-    },
-    database::{
-        actions::{
-            db_delete_spend, db_insert_spend, db_mark_activating_vault,
-            db_mark_broadcastable_spend, db_mark_securing_vault, db_update_presigned_txs,
-            db_update_spend, db_update_vault_status,
-        },
-        interface::{
-            db_cancel_transaction, db_emer_transaction, db_list_spends, db_spend_transaction,
-            db_tip, db_unvault_emer_transaction, db_unvault_transaction, db_vault_by_deposit,
-            db_vault_by_unvault_txid, db_vaults, db_vaults_from_spend, db_vaults_min_status,
-        },
-    },
+    control::{HistoryEventKind, RpcUtils},
     jsonrpc::UserRole,
-    revaultd::{BlockchainTip, VaultStatus},
+    revaultd::VaultStatus,
     threadmessages::{BitcoindThread, SigFetcherMessageOut},
 };
 
 use revault_tx::{
-    bitcoin::{
-        consensus::encode, secp256k1, util::bip32, Address, Amount, OutPoint,
-        PublicKey as BitcoinPubKey, Transaction as BitcoinTransaction, TxOut, Txid,
-    },
-    miniscript::DescriptorTrait,
+    bitcoin::{util::bip32, Address, OutPoint, Txid},
     transactions::{
-        spend_tx_from_deposits, transaction_chain, CancelTransaction, CpfpableTransaction,
-        EmergencyTransaction, RevaultTransaction, SpendTransaction, UnvaultEmergencyTransaction,
+        CancelTransaction, EmergencyTransaction, SpendTransaction, UnvaultEmergencyTransaction,
         UnvaultTransaction,
     },
-    txins::DepositTxIn,
-    txouts::{DepositTxOut, SpendTxOut},
 };
 
 use std::{
@@ -241,58 +218,11 @@ pub trait RpcApi {
     ) -> jsonrpc_core::Result<serde_json::Value>;
 }
 
-// TODO: we should probably make these proc macros and apply them above?
-
-macro_rules! stakeholder_only {
-    ($meta:ident) => {
-        match $meta.role {
-            UserRole::Manager => {
-                // TODO: we should declare some custom error codes instead of
-                // abusing -32602
-                return Err(JsonRpcError::invalid_params(
-                    "This is a stakeholder command".to_string(),
-                ));
-            }
-            _ => {}
-        }
-    };
-}
-
-macro_rules! manager_only {
-    ($meta:ident) => {
-        match $meta.role {
-            UserRole::Stakeholder => {
-                // TODO: we should declare some custom error codes instead of
-                // abusing -32602
-                return Err(JsonRpcError::invalid_params(
-                    "This is a manager command".to_string(),
-                ));
-            }
-            _ => {}
-        }
-    };
-}
-
 macro_rules! parse_vault_status {
     ($status:expr) => {
         VaultStatus::from_str(&$status).map_err(|_| {
             JsonRpcError::invalid_params(format!("'{}' is not a valid vault status", &$status))
         })
-    };
-}
-
-macro_rules! unknown_outpoint {
-    ($outpoint: expr) => {
-        JsonRpcError::invalid_params(format!("No vault at '{}'", $outpoint))
-    };
-}
-
-macro_rules! invalid_status {
-    ($current: expr, $required: expr) => {
-        JsonRpcError::invalid_params(format!(
-            "Invalid vault status: '{}'. Need '{}'",
-            $current, $required
-        ))
     };
 }
 
@@ -314,46 +244,10 @@ impl RpcApi for RpcImpl {
     }
 
     fn getinfo(&self, meta: Self::Metadata) -> jsonrpc_core::Result<serde_json::Value> {
-        let progress = meta.rpc_utils.bitcoind_conn.sync_progress();
-
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
+        let bitcoind = meta.rpc_utils.bitcoind_conn;
 
-        let deposit_desc = &revaultd.deposit_descriptor.to_string();
-        let cpfp_desc = &revaultd.cpfp_descriptor.to_string();
-        let unvault_desc = &revaultd.unvault_descriptor.to_string();
-
-        // This means blockheight == 0 for IBD.
-        let BlockchainTip {
-            height: blockheight,
-            ..
-        } = db_tip(&revaultd.db_file()).map_err(Error::from)?;
-
-        let number_of_vaults = listvaults_from_db(&revaultd, None, None)
-            .map_err(Error::from)?
-            .iter()
-            .filter(|l| {
-                l.status != VaultStatus::Spent
-                    && l.status != VaultStatus::Canceled
-                    && l.status != VaultStatus::Unvaulted
-                    && l.status != VaultStatus::EmergencyVaulted
-            })
-            .count();
-
-        let managers_threshold = meta.rpc_utils.revaultd.read().unwrap().managers_threshold();
-
-        Ok(json!({
-            "version": VERSION.to_string(),
-            "network": revaultd.bitcoind_config.network.to_string(),
-            "blockheight": blockheight,
-            "sync": progress,
-            "vaults": number_of_vaults,
-            "managers_threshold": managers_threshold,
-            "descriptors": {
-                "deposit": deposit_desc,
-                "unvault": unvault_desc,
-                "cpfp": cpfp_desc,
-            },
-        }))
+        Ok(json!(getinfo(&revaultd, &bitcoind)))
     }
 
     fn help(&self, _: Self::Metadata) -> jsonrpc_core::Result<serde_json::Value> {
@@ -445,34 +339,12 @@ impl RpcApi for RpcImpl {
             None
         };
 
-        let vaults = listvaults_from_db(
+        let res = listvaults(
             &meta.rpc_utils.revaultd.read().unwrap(),
             statuses,
             outpoints,
-        )
-        .map_err(Error::from)?;
-
-        let vaults: Vec<serde_json::Value> = vaults
-            .into_iter()
-            .map(|entry| {
-                let derivation_index: u32 = entry.derivation_index.into();
-                json!({
-                    "amount": entry.amount.as_sat(),
-                    "blockheight": entry.blockheight,
-                    "status": entry.status.to_string(),
-                    "txid": entry.deposit_outpoint.txid.to_string(),
-                    "vout": entry.deposit_outpoint.vout,
-                    "derivation_index": derivation_index,
-                    "address": entry.address.to_string(),
-                    "funded_at": entry.funded_at,
-                    "secured_at": entry.secured_at,
-                    "delegated_at": entry.delegated_at,
-                    "moved_at": entry.moved_at,
-                })
-            })
-            .collect();
-
-        Ok(json!({ "vaults": vaults }))
+        );
+        Ok(json!(res))
     }
 
     fn getdepositaddress(
@@ -493,49 +365,10 @@ impl RpcApi for RpcImpl {
         meta: Self::Metadata,
         outpoint: OutPoint,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        stakeholder_only!(meta);
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let db_file = &revaultd.db_file();
+        let res = getrevocationtxs(&revaultd, outpoint)?;
 
-        // First, make sure the vault exists and is confirmed.
-        let vault = db_vault_by_deposit(db_file, &outpoint)
-            .map_err(Error::from)?
-            .ok_or_else(|| {
-                JsonRpcError::invalid_params(format!(
-                    "'{}' does not refer to a known and confirmed vault",
-                    &outpoint,
-                ))
-            })?;
-        if matches!(vault.status, VaultStatus::Unconfirmed) {
-            return Err(JsonRpcError::invalid_params(format!(
-                "'{}' does not refer to a known and confirmed vault",
-                &outpoint,
-            )));
-        };
-
-        let emer_address = revaultd
-            .emergency_address
-            .clone()
-            .expect("The JSONRPC API checked we were a stakeholder");
-
-        let (_, cancel_tx, emergency_tx, unvault_emergency_tx) = transaction_chain(
-            outpoint,
-            vault.amount,
-            &revaultd.deposit_descriptor,
-            &revaultd.unvault_descriptor,
-            &revaultd.cpfp_descriptor,
-            vault.derivation_index,
-            emer_address,
-            revaultd.lock_time,
-            &revaultd.secp_ctx,
-        )
-        .map_err(Error::from)?;
-
-        Ok(json!({
-            "cancel_tx": cancel_tx.as_psbt_string(),
-            "emergency_tx": emergency_tx.as_psbt_string(),
-            "emergency_unvault_tx": unvault_emergency_tx.as_psbt_string(),
-        }))
+        Ok(json!(res))
     }
 
     fn revocationtxs(
@@ -546,219 +379,14 @@ impl RpcApi for RpcImpl {
         emergency_tx: EmergencyTransaction,
         unvault_emergency_tx: UnvaultEmergencyTransaction,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        stakeholder_only!(meta);
-
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let db_path = revaultd.db_file();
-        let secp_ctx = &revaultd.secp_ctx;
-
-        // They may only send revocation transactions for confirmed and not-yet-presigned
-        // vaults.
-        let db_vault = db_vault_by_deposit(&db_path, &outpoint)
-            .map_err(Error::from)?
-            .ok_or_else(|| unknown_outpoint!(outpoint))?;
-        if !matches!(db_vault.status, VaultStatus::Funded) {
-            return Err(invalid_status!(db_vault.status, VaultStatus::Funded));
-        };
-
-        // Sanity check they didn't send us garbaged PSBTs
-        let mut cancel_db_tx = db_cancel_transaction(&db_path, db_vault.id)?
-            .ok_or_else(JsonRpcError::internal_error)?;
-        let rpc_txid = cancel_tx.tx().wtxid();
-        let db_txid = cancel_db_tx.psbt.wtxid();
-        if rpc_txid != db_txid {
-            return Err(JsonRpcError::invalid_params(format!(
-                "Invalid Cancel tx: db wtxid is '{}' but this PSBT's is '{}' ",
-                db_txid, rpc_txid
-            )));
-        }
-        let mut emer_db_tx = db_emer_transaction(&revaultd.db_file(), db_vault.id)?
-            .ok_or_else(JsonRpcError::internal_error)?;
-        let rpc_txid = emergency_tx.tx().wtxid();
-        let db_txid = emer_db_tx.psbt.wtxid();
-        if rpc_txid != db_txid {
-            return Err(JsonRpcError::invalid_params(format!(
-                "Invalid Emergency tx: db wtxid is '{}' but this PSBT's is '{}' ",
-                db_txid, rpc_txid
-            )));
-        }
-        let mut unvault_emer_db_tx = db_unvault_emer_transaction(&revaultd.db_file(), db_vault.id)?
-            .ok_or_else(JsonRpcError::internal_error)?;
-        let rpc_txid = unvault_emergency_tx.tx().wtxid();
-        let db_txid = unvault_emer_db_tx.psbt.wtxid();
-        if rpc_txid != db_txid {
-            return Err(JsonRpcError::invalid_params(format!(
-                "Invalid Unvault Emergency tx: db wtxid is '{}' but this PSBT's is '{}' ",
-                db_txid, rpc_txid
-            )));
-        }
-
-        // Alias some vars we'll reuse
-        let deriv_index = db_vault.derivation_index;
-        let cancel_sigs = &cancel_tx
-            .psbt()
-            .inputs
-            .get(0)
-            .expect("Cancel tx has a single input, inbefore fee bumping.")
-            .partial_sigs;
-        let emer_sigs = &emergency_tx
-            .psbt()
-            .inputs
-            .get(0)
-            .expect("Emergency tx has a single input, inbefore fee bumping.")
-            .partial_sigs;
-        let unvault_emer_sigs = &unvault_emergency_tx
-            .psbt()
-            .inputs
-            .get(0)
-            .expect("UnvaultEmergency tx has a single input, inbefore fee bumping.")
-            .partial_sigs;
-
-        // They must have included *at least* a signature for our pubkey
-        let our_pubkey = revaultd
-            .our_stk_xpub_at(deriv_index)
-            .expect("We are a stakeholder, checked at the beginning of the call.");
-        if !cancel_sigs.contains_key(&our_pubkey) {
-            return Err(JsonRpcError::invalid_params(format!(
-                "No signature for ourselves ({}) in Cancel transaction",
-                our_pubkey
-            )));
-        }
-        // We use the same public key across the transaction chain, that's pretty
-        // neat from an usability perspective.
-        if !emer_sigs.contains_key(&our_pubkey) {
-            return Err(JsonRpcError::invalid_params(
-                "No signature for ourselves in Emergency transaction".to_string(),
-            ));
-        }
-        if !unvault_emer_sigs.contains_key(&our_pubkey) {
-            return Err(JsonRpcError::invalid_params(
-                "No signature for ourselves in UnvaultEmergency transaction".to_string(),
-            ));
-        }
-
-        // There is no reason for them to include an unnecessary signature, so be strict.
-        let stk_keys = revaultd.stakeholders_xpubs_at(deriv_index);
-        for (ref key, _) in cancel_sigs.iter() {
-            if !stk_keys.contains(key) {
-                return Err(JsonRpcError::invalid_params(format!(
-                    "Unknown key in Cancel transaction signatures: {}",
-                    key
-                )));
-            }
-        }
-        for (ref key, _) in emer_sigs.iter() {
-            if !stk_keys.contains(key) {
-                return Err(JsonRpcError::invalid_params(format!(
-                    "Unknown key in Emergency transaction signatures: {}",
-                    key
-                )));
-            }
-        }
-        for (ref key, _) in unvault_emer_sigs.iter() {
-            if !stk_keys.contains(key) {
-                return Err(JsonRpcError::invalid_params(format!(
-                    "Unknown key in UnvaultEmergency transaction signatures: {}",
-                    key
-                )));
-            }
-        }
-
-        // Add the signatures to the DB transactions.
-        for (key, sig) in cancel_sigs {
-            if sig.is_empty() {
-                return Err(JsonRpcError::invalid_params(format!(
-                    "Empty signature for key '{}' in Cancel PSBT",
-                    key
-                )));
-            }
-            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
-                JsonRpcError::invalid_params("Non DER signature in Cancel PSBT".to_string())
-            })?;
-            cancel_db_tx
-                .psbt
-                .add_signature(key.key, sig, secp_ctx)
-                .map_err(|e| {
-                    JsonRpcError::invalid_params(format!(
-                        "Invalid signature '{}' in Cancel PSBT: '{}'",
-                        sig, e
-                    ))
-                })?;
-        }
-        for (key, sig) in emer_sigs {
-            if sig.is_empty() {
-                return Err(JsonRpcError::invalid_params(format!(
-                    "Empty signature for key '{}' in Emergency PSBT",
-                    key
-                )));
-            }
-            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
-                JsonRpcError::invalid_params("Non DER signature in Emergency PSBT".to_string())
-            })?;
-            emer_db_tx
-                .psbt
-                .add_signature(key.key, sig, secp_ctx)
-                .map_err(|e| {
-                    JsonRpcError::invalid_params(format!(
-                        "Invalid signature '{}' in Emergency PSBT: '{}'",
-                        sig, e
-                    ))
-                })?;
-        }
-        for (key, sig) in unvault_emer_sigs {
-            if sig.is_empty() {
-                return Err(JsonRpcError::invalid_params(format!(
-                    "Empty signature for key '{}' in UnvaultEmergency PSBT",
-                    key
-                )));
-            }
-            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
-                JsonRpcError::invalid_params(
-                    "Non DER signature in UnvaultEmergency PSBT".to_string(),
-                )
-            })?;
-            unvault_emer_db_tx
-                .psbt
-                .add_signature(key.key, sig, secp_ctx)
-                .map_err(|e| {
-                    JsonRpcError::invalid_params(format!(
-                        "Invalid signature '{}' in UnvaultEmergency PSBT: '{}'",
-                        sig, e
-                    ))
-                })?;
-        }
-
-        // Then add them to the PSBTs in database. Take care to update the vault
-        // status if all signatures were given via the RPC.
-        let rev_txs = vec![cancel_db_tx, emer_db_tx, unvault_emer_db_tx];
-        db_update_presigned_txs(&db_path, &db_vault, rev_txs.clone(), secp_ctx)?;
-        db_mark_securing_vault(&db_path, db_vault.id)?;
-
-        // If this made the Emergency fully signed and we are a stakeholder, share
-        // it with our watchtowers.
-        let emer_db_tx =
-            db_emer_transaction(&db_path, db_vault.id)?.ok_or_else(JsonRpcError::internal_error)?;
-        if !db_vault.emer_shared && emer_db_tx.psbt.unwrap_emer().is_finalizable(secp_ctx) {
-            if let Some(ref watchtowers) = revaultd.watchtowers {
-                wts_share_emer_signatures(
-                    &revaultd.noise_secret,
-                    watchtowers,
-                    db_vault.deposit_outpoint,
-                    db_vault.derivation_index,
-                    &emer_db_tx,
-                )?;
-            }
-        }
-        db_update_vault_status(&db_path, &db_vault)?;
-
-        // Share them with our felow stakeholders.
-        coord_share_rev_signatures(
-            revaultd.coordinator_host,
-            &revaultd.noise_secret,
-            &revaultd.coordinator_noisekey,
-            &rev_txs,
-        )
-        .map_err(Error::from)?;
+        revocationtxs(
+            &revaultd,
+            outpoint,
+            cancel_tx,
+            emergency_tx,
+            unvault_emergency_tx,
+        )?;
 
         Ok(json!({}))
     }
@@ -768,44 +396,11 @@ impl RpcApi for RpcImpl {
         meta: Self::Metadata,
         outpoint: OutPoint,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        stakeholder_only!(meta);
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let db_file = &revaultd.db_file();
-
-        // We allow the call for Funded 'only' as unvaulttx would later fail if it's
-        // not 'secured'.
-        let vault = db_vault_by_deposit(db_file, &outpoint)
-            .map_err(Error::from)?
-            .ok_or_else(|| unknown_outpoint!(outpoint))?;
-        if matches!(vault.status, VaultStatus::Unconfirmed) {
-            return Err(invalid_status!(vault.status, VaultStatus::Funded));
-        }
-
-        // Derive the descriptors needed to create the UnvaultTransaction
-        let deposit_descriptor = revaultd
-            .deposit_descriptor
-            .derive(vault.derivation_index, &revaultd.secp_ctx);
-        let deposit_txin = DepositTxIn::new(
-            outpoint,
-            DepositTxOut::new(vault.amount, &deposit_descriptor),
-        );
-        let unvault_descriptor = revaultd
-            .unvault_descriptor
-            .derive(vault.derivation_index, &revaultd.secp_ctx);
-        let cpfp_descriptor = revaultd
-            .cpfp_descriptor
-            .derive(vault.derivation_index, &revaultd.secp_ctx);
-
-        let unvault_tx = UnvaultTransaction::new(
-            deposit_txin,
-            &unvault_descriptor,
-            &cpfp_descriptor,
-            revaultd.lock_time,
-        )
-        .map_err(Error::from)?;
+        let unvault_tx = get_unvault_tx(&revaultd, outpoint)?;
 
         Ok(json!({
-            "unvault_tx": unvault_tx.as_psbt_string(),
+            "unvault_tx": unvault_tx,
         }))
     }
 
@@ -815,115 +410,9 @@ impl RpcApi for RpcImpl {
         outpoint: OutPoint,
         unvault_tx: UnvaultTransaction,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        stakeholder_only!(meta);
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let db_path = revaultd.db_file();
-        let secp_ctx = &revaultd.secp_ctx;
 
-        // If they haven't got all the signatures for the revocation transactions, we'd
-        // better not send our unvault sig!
-        // If the vault is already active (or more) there is no point in spamming the
-        // coordinator.
-        let db_vault =
-            db_vault_by_deposit(&db_path, &outpoint)?.ok_or_else(|| unknown_outpoint!(outpoint))?;
-        if !matches!(db_vault.status, VaultStatus::Secured) {
-            return Err(invalid_status!(db_vault.status, VaultStatus::Funded));
-        }
-
-        // Sanity check they didn't send us a garbaged PSBT
-        let mut unvault_db_tx = db_unvault_transaction(&db_path, db_vault.id)?
-            .ok_or_else(JsonRpcError::internal_error)?;
-        let rpc_txid = unvault_tx.tx().wtxid();
-        let db_txid = unvault_db_tx.psbt.wtxid();
-        if rpc_txid != db_txid {
-            return Err(JsonRpcError::invalid_params(format!(
-                "Invalid Unvault tx: db wtxid is '{}' but this PSBT's is '{}' ",
-                db_txid, rpc_txid
-            )));
-        }
-
-        let sigs = &unvault_tx
-            .psbt()
-            .inputs
-            .get(0)
-            .expect("UnvaultTransaction always has 1 input")
-            .partial_sigs;
-        let stk_keys = revaultd.stakeholders_xpubs_at(db_vault.derivation_index);
-        let our_key = revaultd
-            .our_stk_xpub_at(db_vault.derivation_index)
-            .expect("We are a stakeholder, checked at the beginning.");
-        // They must have included *at least* a signature for our pubkey, and must not include an
-        // unnecessary signature.
-        if !sigs.contains_key(&our_key) {
-            return Err(JsonRpcError::invalid_params(format!(
-                "No signature for ourselves ({}) in Unvault transaction",
-                our_key
-            )));
-        }
-
-        for (key, sig) in sigs {
-            // There is no reason for them to include an unnecessary signature, so be strict.
-            if !stk_keys.contains(key) {
-                return Err(JsonRpcError::invalid_params(format!(
-                    "Unknown key in Unvault transaction signatures: {}",
-                    key
-                )));
-            }
-
-            if sig.is_empty() {
-                return Err(JsonRpcError::invalid_params(format!(
-                    "Empty signature for key '{}' in Unvault PSBT",
-                    key
-                )));
-            }
-            let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
-                JsonRpcError::invalid_params("Non DER signature in Unvault PSBT".to_string())
-            })?;
-
-            unvault_db_tx
-                .psbt
-                .add_signature(key.key, sig, secp_ctx)
-                .map_err(|e| {
-                    JsonRpcError::invalid_params(format!(
-                        "Invalid signature '{}' in Unvault PSBT: '{}'",
-                        sig, e
-                    ))
-                })?;
-        }
-
-        // The watchtower(s) MUST have our second-stage (UnvaultEmer, Cancel) signatures
-        // before we share the Unvault one.
-        if let Some(ref watchtowers) = revaultd.watchtowers {
-            let unemer_db_tx = db_unvault_emer_transaction(&db_path, db_vault.id)?
-                .ok_or_else(JsonRpcError::internal_error)?;
-            let cancel_db_tx = db_cancel_transaction(&db_path, db_vault.id)?
-                .ok_or_else(JsonRpcError::internal_error)?;
-            wts_share_second_stage_signatures(
-                &revaultd.noise_secret,
-                watchtowers,
-                db_vault.deposit_outpoint,
-                db_vault.derivation_index,
-                &cancel_db_tx,
-                &unemer_db_tx,
-            )?;
-        }
-
-        // Sanity checks passed. Store it then share it.
-        db_update_presigned_txs(&db_path, &db_vault, vec![unvault_db_tx.clone()], secp_ctx)?;
-        db_mark_activating_vault(&db_path, db_vault.id)?;
-        db_update_vault_status(&db_path, &db_vault)?;
-        share_unvault_signatures(
-            revaultd.coordinator_host,
-            &revaultd.noise_secret,
-            &revaultd.coordinator_noisekey,
-            &unvault_db_tx,
-        )
-        .map_err(|e| {
-            JsonRpcError::invalid_params(format!(
-                "Communication error while sharing Unvault signatures with coordinator: '{}'",
-                e
-            ))
-        })?;
+        set_unvault_tx(&revaultd, outpoint, unvault_tx)?;
 
         Ok(json!({}))
     }
@@ -931,34 +420,12 @@ impl RpcApi for RpcImpl {
     fn listpresignedtransactions(
         &self,
         meta: Self::Metadata,
-        outpoints: Option<Vec<OutPoint>>,
+        outpoints: Option<Vec<OutPoint>>, // FIXME: this needs not be a Vec
     ) -> jsonrpc_core::Result<serde_json::Value> {
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let db_path = revaultd.db_file();
 
-        // If they didn't provide us with a list of outpoints, catch'em all!
-        let db_vaults = if let Some(outpoints) = outpoints {
-            vaults_from_deposits(&db_path, &outpoints, &[VaultStatus::Unconfirmed])
-                .map_err(|e| JsonRpcError::invalid_params(e.to_string()))?
-        } else {
-            db_vaults_min_status(&db_path, VaultStatus::Funded).map_err(Error::from)?
-        };
-        let vaults = presigned_txs(&revaultd, db_vaults).map_err(Error::from)?;
-
-        let vaults: Vec<serde_json::Value> = vaults
-            .into_iter()
-            .map(|v| {
-                json!({
-                    "vault_outpoint": v.outpoint,
-                    "unvault": v.unvault,
-                    "cancel": v.cancel,
-                    "emergency": v.emergency,
-                    "unvault_emergency": v.unvault_emergency,
-                })
-            })
-            .collect();
-
-        Ok(json!({ "presigned_transactions": vaults }))
+        let pres_txs = presigned_transactions(&revaultd, &outpoints.as_deref().unwrap_or(&[]))?;
+        Ok(json!({ "presigned_transactions": pres_txs }))
     }
 
     fn listonchaintransactions(
@@ -967,48 +434,11 @@ impl RpcApi for RpcImpl {
         outpoints: Option<Vec<OutPoint>>,
     ) -> jsonrpc_core::Result<serde_json::Value> {
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let db_path = revaultd.db_file();
+        let bitcoind = meta.rpc_utils.bitcoind_conn;
 
-        // If they didn't provide us with a list of outpoints, catch'em all!
-        let db_vaults = if let Some(outpoints) = outpoints {
-            // We accept any status
-            vaults_from_deposits(&db_path, &outpoints, &[])
-                .map_err(|e| JsonRpcError::invalid_params(e.to_string()))?
-        } else {
-            db_vaults(&db_path).map_err(Error::from)?
-        };
-        let vaults = onchain_txs(
-            &meta.rpc_utils.revaultd.read().unwrap(),
-            &meta.rpc_utils.bitcoind_conn,
-            db_vaults,
-        )
-        .map_err(Error::from)?;
-
-        fn wallet_tx_to_json(tx: WalletTransaction) -> serde_json::Value {
-            json!({
-                "blockheight": tx.blockheight.map(serde_json::Number::from),
-                "blocktime": tx.blocktime.map(serde_json::Number::from),
-                "received_at": serde_json::Number::from(tx.received_time),
-                "hex": serde_json::Value::String(tx.hex),
-            })
-        }
-        let vaults: Vec<serde_json::Value> = vaults
-            .into_iter()
-            .map(|v| {
-                json!({
-                    "vault_outpoint": v.outpoint,
-                    "deposit": wallet_tx_to_json(v.deposit),
-                    "unvault": v.unvault.map(wallet_tx_to_json),
-                    "cancel": v.cancel.map(wallet_tx_to_json),
-                    "emergency": v.emergency.map(wallet_tx_to_json),
-                    "unvault_emergency": v.unvault_emergency.map(wallet_tx_to_json),
-                    "spend": v.spend.map(wallet_tx_to_json),
-                })
-            })
-            .collect();
-
+        let txs = onchain_transactions(&revaultd, &bitcoind, &outpoints.as_deref().unwrap_or(&[]))?;
         Ok(json!({
-            "onchain_transactions": vaults,
+            "onchain_transactions": txs,
         }))
     }
 
@@ -1019,8 +449,6 @@ impl RpcApi for RpcImpl {
         destinations: BTreeMap<Address, u64>,
         feerate_vb: u64,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        manager_only!(meta);
-
         if feerate_vb < 1 {
             return Err(JsonRpcError::invalid_params(
                 "Feerate can't be <1".to_string(),
@@ -1028,149 +456,9 @@ impl RpcApi for RpcImpl {
         }
 
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let db_file = &revaultd.db_file();
-
-        // Reconstruct the DepositTxin s from the outpoints and the vaults informations
-        let mut txins = Vec::with_capacity(outpoints.len());
-        // If we need a change output, use the highest derivation index of the vaults
-        // spent. This avoids leaking a new address needlessly while not introducing
-        // disrepancy between our indexes.
-        let mut change_index = bip32::ChildNumber::from(0);
-        for outpoint in outpoints.iter() {
-            let vault = db_vault_by_deposit(db_file, outpoint)
-                .map_err(Error::from)?
-                .ok_or_else(|| unknown_outpoint!(outpoint))?;
-            if matches!(vault.status, VaultStatus::Active) {
-                if vault.derivation_index > change_index {
-                    change_index = vault.derivation_index;
-                }
-                txins.push((*outpoint, vault.amount, vault.derivation_index));
-            } else {
-                return Err(invalid_status!(vault.status, VaultStatus::Active));
-            }
-        }
-
-        let txos: Vec<SpendTxOut> = destinations
-            .into_iter()
-            .map(|(addr, value)| {
-                let script_pubkey = addr.script_pubkey();
-                SpendTxOut::new(TxOut {
-                    value,
-                    script_pubkey,
-                })
-            })
-            .collect();
-
-        log::debug!(
-            "Creating a Spend transaction with deposit txins: '{:?}' and txos: '{:?}'",
-            &txins,
-            &txos
-        );
-
-        // This adds the CPFP output so create a dummy one to accurately compute the
-        // feerate.
-        let nochange_tx = spend_tx_from_deposits(
-            txins.clone(),
-            txos.clone(),
-            None, // No change :)
-            &revaultd.deposit_descriptor,
-            &revaultd.unvault_descriptor,
-            &revaultd.cpfp_descriptor,
-            revaultd.lock_time,
-            /* Deactivate insane feerate check */
-            false,
-            &revaultd.secp_ctx,
-        )
-        .map_err(|e| {
-            JsonRpcError::invalid_params(format!("Error while building spend transaction: {}", e))
-        })?;
-
-        log::debug!(
-            "Spend tx without change: '{}'",
-            nochange_tx.as_psbt_string()
-        );
-
-        // If the feerate of the transaction would be much lower (< 90/100) than what they
-        // requested for, tell them.
-        let nochange_feerate_vb = nochange_tx
-            .max_feerate()
-            .checked_mul(4)
-            .expect("bug in feerate computation");
-        if nochange_feerate_vb * 10 < feerate_vb * 9 {
-            return Err(JsonRpcError::invalid_params(format!(
-                "Required feerate ('{}') is significantly higher than actual feerate ('{}')",
-                feerate_vb, nochange_feerate_vb
-            )));
-        }
-
-        // Add a change output if it would not be dust according to our standard (200k sats
-        // atm, see DUST_LIMIT).
-        // 8 (amount) + 1 (len) + 1 (v0) + 1 (push) + 32 (witscript hash)
-        const P2WSH_TXO_WEIGHT: u64 = 43 * 4;
-        let with_change_weight = nochange_tx
-            .max_weight()
-            .checked_add(P2WSH_TXO_WEIGHT)
-            .expect("weight computation bug");
-        let cur_fees = nochange_tx.fees();
-        let want_fees = with_change_weight
-            // Mental gymnastic: sat/vbyte to sat/wu rounded up
-            .checked_mul(feerate_vb + 3)
-            .map(|vbyte| vbyte.checked_div(4).unwrap());
-        let change_value = want_fees.map(|f| cur_fees.checked_sub(f)).flatten();
-        log::debug!(
-            "Weight with change: '{}'  --  Fees without change: '{}'  --  Wanted feerate: '{}'  \
-                    --  Wanted fees: '{:?}'  --  Change value: '{:?}'",
-            with_change_weight,
-            cur_fees,
-            feerate_vb,
-            want_fees,
-            change_value
-        );
-
-        let change_txo = change_value.and_then(|change_value| {
-            // The overhead incurred to the value of the CPFP output by the change output
-            // See https://github.com/revault/practical-revault/blob/master/transactions.md#spend_tx
-            let cpfp_overhead = 16 * P2WSH_TXO_WEIGHT;
-            if change_value > revault_tx::transactions::DUST_LIMIT + cpfp_overhead {
-                let change_txo = DepositTxOut::new(
-                    // arithmetic checked above
-                    Amount::from_sat(change_value - cpfp_overhead),
-                    &revaultd
-                        .deposit_descriptor
-                        .derive(change_index, &revaultd.secp_ctx),
-                );
-                log::debug!("Adding a change txo: '{:?}'", change_txo);
-                Some(change_txo)
-            } else {
-                None
-            }
-        });
-
-        // Now we can hand them the resulting transaction (sanity checked for insane fees).
-        let tx_res = spend_tx_from_deposits(
-            txins,
-            txos,
-            change_txo,
-            &revaultd.deposit_descriptor,
-            &revaultd.unvault_descriptor,
-            &revaultd.cpfp_descriptor,
-            revaultd.lock_time,
-            true,
-            &revaultd.secp_ctx,
-        )
-        .map_err(|e| {
-            JsonRpcError::invalid_params(format!("Error while building spend transaction: {}", e))
-        })?;
-
-        if !check_spend_transaction_size(&revaultd, tx_res.clone()) {
-            return Err(JsonRpcError::invalid_params(
-                "Spend transaction is too large, try spending less outpoints".to_string(),
-            ));
-        };
-        log::debug!("Final Spend transaction: '{:?}'", tx_res);
-
+        let tx = get_spend_tx(&revaultd, &outpoints, destinations, feerate_vb)?;
         Ok(json!({
-            "spend_tx": tx_res.as_psbt_string(),
+            "spend_tx": tx,
         }))
     }
 
@@ -1179,45 +467,8 @@ impl RpcApi for RpcImpl {
         meta: Self::Metadata,
         spend_tx: SpendTransaction,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        manager_only!(meta);
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let db_path = revaultd.db_file();
-        let spend_txid = spend_tx.tx().txid();
-
-        // Fetch the Unvault it spends from the DB
-        let spend_inputs = &spend_tx.tx().input;
-        let mut db_unvaults = Vec::with_capacity(spend_inputs.len());
-        for txin in spend_inputs.iter() {
-            let (db_vault, db_unvault) =
-                db_vault_by_unvault_txid(&db_path, &txin.previous_output.txid)
-                    .map_err(Error::from)?
-                    .ok_or_else(|| {
-                        JsonRpcError::invalid_params(format!(
-                            "Spend transaction refers an unknown Unvault: '{}'",
-                            txin.previous_output.txid
-                        ))
-                    })?;
-
-            if !matches!(db_vault.status, VaultStatus::Active) {
-                return Err(invalid_status!(db_vault.status, VaultStatus::Active));
-            }
-
-            db_unvaults.push(db_unvault);
-        }
-
-        // The user has the ability to set priority to the transaction in
-        // setspendtx, here we always set it to false.
-
-        if db_spend_transaction(&db_path, &spend_txid)
-            .map_err(Error::from)?
-            .is_some()
-        {
-            log::debug!("Updating Spend transaction '{}'", spend_txid);
-            db_update_spend(&db_path, &spend_tx, false).map_err(Error::from)?;
-        } else {
-            log::debug!("Storing new Spend transaction '{}'", spend_txid);
-            db_insert_spend(&db_path, &db_unvaults, &spend_tx).map_err(Error::from)?;
-        }
+        update_spend_tx(&revaultd, spend_tx)?;
 
         Ok(json!({}))
     }
@@ -1227,12 +478,8 @@ impl RpcApi for RpcImpl {
         meta: Self::Metadata,
         spend_txid: Txid,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        manager_only!(meta);
-
-        let db_path = meta.rpc_utils.revaultd.read().unwrap().db_file();
-
-        db_delete_spend(&db_path, &spend_txid)
-            .map_err(|e| JsonRpcError::invalid_params(e.to_string()))?;
+        let revaultd = meta.rpc_utils.revaultd.read().unwrap();
+        del_spend_tx(&revaultd, &spend_txid)?;
 
         Ok(json!({}))
     }
@@ -1242,68 +489,10 @@ impl RpcApi for RpcImpl {
         meta: Self::Metadata,
         status: Option<Vec<ListSpendStatus>>,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        manager_only!(meta);
-
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let db_path = revaultd.db_file();
+        let txs = list_spend_txs(&revaultd, status.as_deref())?;
 
-        let spend_tx_map = db_list_spends(&db_path).map_err(Error::from)?;
-        let mut listspend_entries = Vec::with_capacity(spend_tx_map.len());
-        for (_, (db_spend, deposit_outpoints)) in spend_tx_map {
-            // Filter by status
-            if let Some(s) = &status {
-                let status = if let Some(true) = db_spend.broadcasted {
-                    ListSpendStatus::Broadcasted
-                } else if let Some(false) = db_spend.broadcasted {
-                    ListSpendStatus::Pending
-                } else {
-                    ListSpendStatus::NonFinal
-                };
-
-                if !s.contains(&status) {
-                    continue;
-                }
-            }
-
-            let spent_vaults =
-                db_vaults_from_spend(&db_path, &db_spend.psbt.txid()).map_err(Error::from)?;
-
-            let derivation_index = spent_vaults
-                .values()
-                .map(|v| v.derivation_index)
-                .max()
-                .expect("Spent vaults should not be empty");
-            let cpfp_script_pubkey = revaultd
-                .cpfp_descriptor
-                .derive(derivation_index, &revaultd.secp_ctx)
-                .into_inner()
-                .script_pubkey();
-            let deposit_address = revaultd
-                .deposit_descriptor
-                .derive(derivation_index, &revaultd.secp_ctx)
-                .into_inner()
-                .script_pubkey();
-            let mut cpfp_index = None;
-            let mut change_index = None;
-            for (i, txout) in db_spend.psbt.tx().output.iter().enumerate() {
-                if cpfp_index.is_none() && cpfp_script_pubkey == txout.script_pubkey {
-                    cpfp_index = Some(i);
-                }
-
-                if deposit_address == txout.script_pubkey {
-                    change_index = Some(i);
-                }
-            }
-
-            listspend_entries.push(ListSpendEntry {
-                psbt: db_spend.psbt,
-                deposit_outpoints,
-                cpfp_index: cpfp_index.expect("We always create a CPFP output"),
-                change_index,
-            });
-        }
-
-        Ok(json!({ "spend_txs": listspend_entries }))
+        Ok(json!({ "spend_txs": txs }))
     }
 
     fn setspendtx(
@@ -1312,150 +501,10 @@ impl RpcApi for RpcImpl {
         spend_txid: Txid,
         priority: Option<bool>,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        manager_only!(meta);
-
         let priority = priority.unwrap_or(false);
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let db_path = revaultd.db_file();
-
-        if priority && revaultd.cpfp_key.is_none() {
-            return Err(JsonRpcError::invalid_params(
-                "Can't read the cpfp key. \
-                    Make sure you have a file called cpfp_secret containing \
-                    the private key in your datadir"
-                    .to_string(),
-            ));
-        }
-
-        // Get the referenced Spend and the vaults it spends from the DB
-        let mut spend_tx = db_spend_transaction(&db_path, &spend_txid)
-            .map_err(Error::from)?
-            .ok_or_else(|| JsonRpcError::invalid_params("Unknown Spend transaction".to_string()))?;
-        let spent_vaults = db_vaults_from_spend(&db_path, &spend_txid).map_err(Error::from)?;
-        let tx = &spend_tx.psbt.tx();
-        if spent_vaults.len() < tx.input.len() {
-            return Err(JsonRpcError::invalid_params(
-                "Spend transaction refers to an already spent vault".to_string(),
-            ));
-        }
-
-        // Sanity check the Spend transaction is actually valid before announcing
-        // it. revault_tx already implements the signature checks so don't duplicate
-        // the logic and re-add the signatures to the PSBT.
-        let signatures: Vec<BTreeMap<BitcoinPubKey, Vec<u8>>> = spend_tx
-            .psbt
-            .psbt()
-            .inputs
-            .iter()
-            .map(|i| i.partial_sigs.clone())
-            .collect();
-        let mans_thresh = revaultd.managers_threshold();
-        for (i, sigmap) in signatures.iter().enumerate() {
-            if sigmap.len() < mans_thresh {
-                return Err(JsonRpcError::invalid_params(format!(
-                    "Not enough signatures, needed: {}, current: {}",
-                    mans_thresh,
-                    sigmap.len()
-                )));
-            }
-            for (pubkey, sig) in sigmap {
-                let sig = secp256k1::Signature::from_der(&sig[..sig.len() - 1]).map_err(|_| {
-                    JsonRpcError::invalid_params(format!(
-                        "Spend PSBT contains an invalid signature: '{}'",
-                        encode::serialize_hex(&sig)
-                    ))
-                })?;
-                spend_tx
-                    .psbt
-                    .add_signature(i, pubkey.key, sig, &revaultd.secp_ctx)
-                    .map_err(|_| {
-                        JsonRpcError::invalid_params(format!(
-                            "Spend PSBT contains an invalid signature: '{}'",
-                            encode::serialize_hex(&sig.serialize_der().to_vec())
-                        ))
-                    })?
-                    .expect("The signature was already there");
-            }
-        }
-
-        // Check that we can actually send the tx to the coordinator...
-        if !check_spend_transaction_size(&revaultd, spend_tx.psbt.clone()) {
-            return Err(JsonRpcError::invalid_params(
-                "Spend transaction is too large, try spending less outpoints".to_string(),
-            ));
-        };
-
-        // Now, if needed, we can ask all the cosigning servers for their
-        // signatures
-        let cosigs = revaultd.cosigs.as_ref().expect("We are manager");
-        if !cosigs.is_empty() {
-            log::debug!("Fetching signatures from Cosigning servers");
-            fetch_cosigs_signatures(
-                &revaultd.secp_ctx,
-                &revaultd.noise_secret,
-                &mut spend_tx.psbt,
-                cosigs,
-            )
-            .map_err(|e| {
-                JsonRpcError::invalid_params(format!(
-                    "Communication error while fetching cosigner signatures: {}",
-                    e,
-                ))
-            })?;
-        }
-        let mut finalized_spend = spend_tx.psbt.clone();
-        finalized_spend.finalize(&revaultd.secp_ctx).map_err(|e| {
-            JsonRpcError::invalid_params(format!(
-                "Could not finalize Spend transaction, psbt: '{}' (error: '{}')",
-                spend_tx.psbt, e
-            ))
-        })?;
-
-        // And then announce it to the Coordinator
-        let deposit_outpoints: Vec<_> = spent_vaults
-            .values()
-            .map(|db_vault| db_vault.deposit_outpoint)
-            .collect();
-        announce_spend_transaction(
-            revaultd.coordinator_host,
-            &revaultd.noise_secret,
-            &revaultd.coordinator_noisekey,
-            finalized_spend,
-            deposit_outpoints,
-        )
-        .map_err(|e| {
-            JsonRpcError::invalid_params(format!(
-                "Communication error while announcing the Spend transaction: {}",
-                e
-            ))
-        })?;
-        db_update_spend(&db_path, &spend_tx.psbt, priority).map_err(Error::from)?;
-
-        // Finally we can broadcast the Unvault(s) transaction(s) and store the Spend
-        // transaction for later broadcast
-        log::debug!(
-            "Broadcasting Unvault transactions with ids '{:?}'",
-            spent_vaults.keys()
-        );
-        let bitcoin_txs = spent_vaults
-            .values()
-            .into_iter()
-            .map(|db_vault| {
-                let mut unvault_tx = db_unvault_transaction(&db_path, db_vault.id)?
-                    .ok_or_else(JsonRpcError::internal_error)?
-                    .psbt
-                    .assert_unvault();
-                unvault_tx
-                    .finalize(&revaultd.secp_ctx)
-                    .map_err(Error::from)?;
-                Ok(unvault_tx.into_psbt().extract_tx())
-            })
-            .collect::<Result<Vec<BitcoinTransaction>, JsonRpcError>>()?;
-        meta.rpc_utils
-            .bitcoind_conn
-            .broadcast(bitcoin_txs)
-            .map_err(Error::from)?;
-        db_mark_broadcastable_spend(&db_path, &spend_txid).map_err(Error::from)?;
+        let bitcoind = meta.rpc_utils.bitcoind_conn;
+        set_spend_tx(&revaultd, &bitcoind, &spend_txid, priority)?;
 
         Ok(json!({}))
     }
@@ -1466,69 +515,24 @@ impl RpcApi for RpcImpl {
         deposit_outpoint: OutPoint,
     ) -> jsonrpc_core::Result<serde_json::Value> {
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let db_path = revaultd.db_file();
-
-        // Checking that the vault is secured, otherwise we don't have the cancel
-        // transaction
-        let vault = db_vault_by_deposit(&db_path, &deposit_outpoint)
-            .map_err(Error::from)?
-            .ok_or_else(|| unknown_outpoint!(deposit_outpoint))?;
-
-        if !matches!(
-            vault.status,
-            VaultStatus::Unvaulting | VaultStatus::Unvaulted | VaultStatus::Spending
-        ) {
-            return Err(invalid_status!(vault.status, VaultStatus::Unvaulting));
-        }
-
-        let mut cancel_tx = db_cancel_transaction(&db_path, vault.id)?
-            .ok_or_else(JsonRpcError::internal_error)?
-            .psbt
-            .assert_cancel();
-
-        cancel_tx
-            .finalize(&revaultd.secp_ctx)
-            .map_err(Error::from)?;
-        let transaction = cancel_tx.into_psbt().extract_tx();
-        log::debug!(
-            "Broadcasting Cancel transactions with id '{:?}'",
-            transaction.txid()
-        );
-        meta.rpc_utils
-            .bitcoind_conn
-            .broadcast(vec![transaction])
-            .map_err(Error::from)?;
+        let bitcoind = meta.rpc_utils.bitcoind_conn;
+        revault(&revaultd, &bitcoind, &deposit_outpoint)?;
 
         Ok(json!({}))
     }
 
     fn emergency(&self, meta: Self::Metadata) -> jsonrpc_core::Result<serde_json::Value> {
-        stakeholder_only!(meta);
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-
-        // FIXME: there is a ton of edge cases not covered here. We should additionally opt for a
-        // bulk method, like broadcasting all Emergency transactions in a thread forever without
-        // trying to be smart by differentiating between Emer and UnvaultEmer until we die or all
-        // vaults are confirmed in the EDV.
-        let emers = finalized_emer_txs(&revaultd).map_err(Error::from)?;
-        meta.rpc_utils
-            .bitcoind_conn
-            .broadcast(emers)
-            .map_err(Error::from)?;
+        let bitcoind = meta.rpc_utils.bitcoind_conn;
+        emergency(&revaultd, &bitcoind)?;
 
         Ok(json!({}))
     }
 
     fn getserverstatus(&self, meta: Self::Metadata) -> jsonrpc_core::Result<serde_json::Value> {
         let revaultd = meta.rpc_utils.revaultd.read().unwrap();
-        let coordinator = coordinator_status(&revaultd);
-        let cosigners = cosigners_status(&revaultd);
-        let watchtowers = watchtowers_status(&revaultd);
-        Ok(json!({
-            "coordinator": coordinator,
-            "cosigners": cosigners,
-            "watchtowers": watchtowers,
-        }))
+        let status = get_servers_statuses(&revaultd);
+        Ok(json!(status))
     }
 
     /// get_history retrieves a limited list of events which occured between two given dates.
@@ -1549,8 +553,7 @@ impl RpcApi for RpcImpl {
             end,
             limit,
             kind,
-        )
-        .map_err(Error::from)?;
+        )?;
 
         Ok(json!({
             "events": events,

--- a/src/jsonrpc/api/mod.rs
+++ b/src/jsonrpc/api/mod.rs
@@ -323,16 +323,15 @@ impl RpcApi for RpcImpl {
         Ok(json!(res))
     }
 
-    // TODO: make it a command
     fn getdepositaddress(
         &self,
         meta: Self::Metadata,
         index: Option<bip32::ChildNumber>,
     ) -> jsonrpc_core::Result<serde_json::Value> {
         let address = if let Some(index) = index {
-            meta.rpc_utils.revaultd.read().unwrap().vault_address(index)
+            meta.rpc_utils.get_deposit_address_at(index)
         } else {
-            meta.rpc_utils.revaultd.read().unwrap().deposit_address()
+            meta.rpc_utils.get_deposit_address()
         };
         Ok(json!({ "address": address.to_string() }))
     }

--- a/src/jsonrpc/api/mod.rs
+++ b/src/jsonrpc/api/mod.rs
@@ -11,9 +11,8 @@ use crate::{
         presigned_transactions, revault, revocationtxs, set_spend_tx, set_unvault_tx,
         update_spend_tx, HistoryEventKind, ListSpendStatus,
     },
-    jsonrpc::RpcUtils,
     revaultd::VaultStatus,
-    threadmessages::{BitcoindThread, SigFetcherThread},
+    DaemonControl,
 };
 
 use revault_tx::{
@@ -40,12 +39,12 @@ use serde_json::json;
 #[derive(Clone)]
 pub struct JsonRpcMetaData {
     pub shutdown: Arc<AtomicBool>,
-    pub rpc_utils: RpcUtils,
+    pub rpc_utils: DaemonControl,
 }
 impl jsonrpc_core::Metadata for JsonRpcMetaData {}
 
 impl JsonRpcMetaData {
-    pub fn new(rpc_utils: RpcUtils) -> Self {
+    pub fn new(rpc_utils: DaemonControl) -> Self {
         JsonRpcMetaData {
             shutdown: Arc::from(AtomicBool::from(false)),
             rpc_utils,
@@ -227,12 +226,8 @@ impl RpcApi for RpcImpl {
     type Metadata = JsonRpcMetaData;
 
     fn stop(&self, meta: JsonRpcMetaData) -> jsonrpc_core::Result<()> {
-        log::info!("Stopping revaultd");
-
-        meta.rpc_utils.bitcoind_conn.shutdown();
-        meta.rpc_utils.sigfetcher_conn.shutdown();
+        // Stop the server loop. Caller will clean up itself.
         meta.shutdown();
-
         Ok(())
     }
 

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -6,16 +6,13 @@ use crate::{
     threadmessages::{BitcoindSender, SigFetcherSender},
 };
 
-use std::{
-    sync::{Arc, RwLock},
-    thread::JoinHandle,
-};
+use std::sync::{Arc, RwLock};
 
+// TODO: would be nice to harmonize with DaemonHandle..
+/// Data needed to handle JSONRPC requests.
 #[derive(Clone)]
 pub struct RpcUtils {
     pub revaultd: Arc<RwLock<RevaultD>>,
     pub bitcoind_conn: BitcoindSender,
-    pub bitcoind_thread: Arc<RwLock<JoinHandle<()>>>,
     pub sigfetcher_conn: SigFetcherSender,
-    pub sigfetcher_thread: Arc<RwLock<JoinHandle<()>>>,
 }

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -1,6 +1,16 @@
 mod api;
 pub mod server;
 
+use crate::{
+    revaultd::RevaultD,
+    threadmessages::{BitcoindSender, SigFetcherMessageOut},
+};
+
+use std::{
+    sync::{mpsc::Sender, Arc, RwLock},
+    thread::JoinHandle,
+};
+
 /// Some calls are Stakeholder-only or Manager-only. This makes the API code
 /// aware of whether we were started as such to immediately forbid some of them.
 #[derive(Debug, Clone, Copy)]
@@ -8,4 +18,13 @@ pub enum UserRole {
     Manager,
     Stakeholder,
     ManagerStakeholder,
+}
+
+#[derive(Clone)]
+pub struct RpcUtils {
+    pub revaultd: Arc<RwLock<RevaultD>>,
+    pub bitcoind_conn: BitcoindSender,
+    pub bitcoind_thread: Arc<RwLock<JoinHandle<()>>>,
+    pub sigfetcher_tx: Sender<SigFetcherMessageOut>,
+    pub sigfetcher_thread: Arc<RwLock<JoinHandle<()>>>,
 }

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -3,11 +3,11 @@ pub mod server;
 
 use crate::{
     revaultd::RevaultD,
-    threadmessages::{BitcoindSender, SigFetcherMessageOut},
+    threadmessages::{BitcoindSender, SigFetcherSender},
 };
 
 use std::{
-    sync::{mpsc::Sender, Arc, RwLock},
+    sync::{Arc, RwLock},
     thread::JoinHandle,
 };
 
@@ -25,6 +25,6 @@ pub struct RpcUtils {
     pub revaultd: Arc<RwLock<RevaultD>>,
     pub bitcoind_conn: BitcoindSender,
     pub bitcoind_thread: Arc<RwLock<JoinHandle<()>>>,
-    pub sigfetcher_tx: Sender<SigFetcherMessageOut>,
+    pub sigfetcher_conn: SigFetcherSender,
     pub sigfetcher_thread: Arc<RwLock<JoinHandle<()>>>,
 }

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -1,18 +1,2 @@
 mod api;
 pub mod server;
-
-use crate::{
-    revaultd::RevaultD,
-    threadmessages::{BitcoindSender, SigFetcherSender},
-};
-
-use std::sync::{Arc, RwLock};
-
-// TODO: would be nice to harmonize with DaemonHandle..
-/// Data needed to handle JSONRPC requests.
-#[derive(Clone)]
-pub struct RpcUtils {
-    pub revaultd: Arc<RwLock<RevaultD>>,
-    pub bitcoind_conn: BitcoindSender,
-    pub sigfetcher_conn: SigFetcherSender,
-}

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -11,15 +11,6 @@ use std::{
     thread::JoinHandle,
 };
 
-/// Some calls are Stakeholder-only or Manager-only. This makes the API code
-/// aware of whether we were started as such to immediately forbid some of them.
-#[derive(Debug, Clone, Copy)]
-pub enum UserRole {
-    Manager,
-    Stakeholder,
-    ManagerStakeholder,
-}
-
 #[derive(Clone)]
 pub struct RpcUtils {
     pub revaultd: Arc<RwLock<RevaultD>>,

--- a/src/jsonrpc/server.rs
+++ b/src/jsonrpc/server.rs
@@ -2,10 +2,9 @@
 //! Actual JSONRPC2 commands are handled in the `api` mod.
 
 use crate::{
-    control::RpcUtils,
     jsonrpc::{
         api::{JsonRpcMetaData, RpcApi, RpcImpl},
-        UserRole,
+        UserRole, RpcUtils
     },
 };
 

--- a/src/jsonrpc/server.rs
+++ b/src/jsonrpc/server.rs
@@ -461,10 +461,13 @@ pub fn rpcserver_setup(socket_path: PathBuf) -> Result<UnixListener, io::Error> 
 }
 
 /// The main event loop for the JSONRPC interface, polling the UDS listener
-pub fn rpcserver_loop(listener: UnixListener, rpc_utils: DaemonControl) -> Result<(), io::Error> {
+pub fn rpcserver_loop(
+    listener: UnixListener,
+    daemon_control: DaemonControl,
+) -> Result<(), io::Error> {
     let mut jsonrpc_io = jsonrpc_core::MetaIoHandler::<JsonRpcMetaData, _>::default();
     jsonrpc_io.extend_with(RpcImpl.to_delegate());
-    let metadata = JsonRpcMetaData::new(rpc_utils);
+    let metadata = JsonRpcMetaData::new(daemon_control);
 
     log::info!("JSONRPC server started.");
     #[cfg(not(windows))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub use revault_net;
 pub use revault_tx;
 
 mod bitcoind;
+pub mod commands;
 mod communication;
 pub mod config;
 mod control;
@@ -12,6 +13,7 @@ mod sigfetcher;
 mod threadmessages;
 mod utils;
 
+// FIXME: make it an integer
 pub const VERSION: &str = "0.3.1";
 
 use crate::{
@@ -26,6 +28,7 @@ use crate::{
     threadmessages::BitcoindSender,
 };
 
+// FIXME
 pub use crate::revaultd::RevaultD;
 
 use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ mod bitcoind;
 pub mod commands;
 mod communication;
 pub mod config;
-mod control;
 mod database;
 mod jsonrpc;
 mod revaultd;
@@ -18,11 +17,10 @@ pub const VERSION: &str = "0.3.1";
 
 use crate::{
     bitcoind::{bitcoind_main_loop, start_bitcoind},
-    control::RpcUtils,
     database::actions::setup_db,
     jsonrpc::{
         server::{rpcserver_loop, rpcserver_setup},
-        UserRole,
+        RpcUtils, UserRole,
     },
     sigfetcher::signature_fetcher_loop,
     threadmessages::BitcoindSender,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 mod database;
 mod jsonrpc;
 mod revaultd;
+pub use crate::revaultd::*;
 mod sigfetcher;
 mod threadmessages;
 mod utils;
@@ -25,9 +26,6 @@ use crate::{
     sigfetcher::signature_fetcher_loop,
     threadmessages::BitcoindSender,
 };
-
-// FIXME
-pub use crate::revaultd::RevaultD;
 
 use std::{
     io::{self, Write},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,12 +88,11 @@ impl From<DatabaseError> for StartupError {
     }
 }
 
-// FIXME: private fields
 #[derive(Clone)]
 pub struct DaemonControl {
-    pub revaultd: Arc<RwLock<RevaultD>>,
-    pub bitcoind_conn: BitcoindSender,
-    pub sigfetcher_conn: SigFetcherSender,
+    revaultd: Arc<RwLock<RevaultD>>,
+    bitcoind_conn: BitcoindSender,
+    sigfetcher_conn: SigFetcherSender,
 }
 
 impl DaemonControl {

--- a/src/revaultd.rs
+++ b/src/revaultd.rs
@@ -20,16 +20,12 @@ use revault_tx::{
     bitcoin::{
         secp256k1,
         util::bip32::{self, ChildNumber, ExtendedPrivKey, ExtendedPubKey},
-        Address, BlockHash, Network, PublicKey as BitcoinPublicKey, Script, TxOut,
+        Address, BlockHash, Network, PublicKey as BitcoinPublicKey, Script,
     },
     miniscript::descriptor::{DescriptorPublicKey, DescriptorTrait},
     scripts::{
         CpfpDescriptor, DepositDescriptor, DerivedCpfpDescriptor, DerivedDepositDescriptor,
         DerivedUnvaultDescriptor, EmergencyAddress, UnvaultDescriptor,
-    },
-    transactions::{
-        CancelTransaction, DepositTransaction, EmergencyTransaction, UnvaultEmergencyTransaction,
-        UnvaultTransaction,
     },
 };
 
@@ -155,7 +151,7 @@ impl fmt::Display for VaultStatus {
     }
 }
 
-// An error related to the initialization of communication keys
+/// An error related to the initialization of communication keys.
 #[derive(Debug)]
 enum NoiseKeyError {
     ReadingKey(io::Error),
@@ -173,8 +169,9 @@ impl fmt::Display for NoiseKeyError {
 
 impl std::error::Error for NoiseKeyError {}
 
+/// An error related to the initialization of the CPFP private key.
 #[derive(Debug)]
-enum CpfpKeyError {
+pub enum CpfpKeyError {
     InvalidSeedFile,
     ReadingSeed(io::Error),
     InvalidSeed(bip32::Error),
@@ -269,22 +266,7 @@ fn read_cpfp_key(
         .map(Option::Some)
 }
 
-/// A vault is defined as a confirmed utxo paying to the Vault Descriptor for which
-/// we have a set of pre-signed transaction (emergency, cancel, unvault).
-/// Depending on its status we may not yet be in possession of part -or the entirety-
-/// of the pre-signed transactions.
-/// Likewise, depending on our role (manager or stakeholder), we may not have the
-/// emergency transactions.
-pub struct _Vault {
-    pub deposit_txo: TxOut,
-    pub status: VaultStatus,
-    pub vault_tx: Option<DepositTransaction>,
-    pub emergency_tx: Option<EmergencyTransaction>,
-    pub unvault_tx: Option<UnvaultTransaction>,
-    pub cancel_tx: Option<CancelTransaction>,
-    pub unvault_emergency_tx: Option<UnvaultEmergencyTransaction>,
-}
-
+/// Information about the last block in the chain.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct BlockchainTip {
     pub height: u32,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -112,7 +112,7 @@ addr = "127.0.0.1:8332"
             revaultd,
             bitcoind_conn: BitcoindSender::from(bitcoind_tx),
             bitcoind_thread,
-            sigfetcher_tx,
+            sigfetcher_conn: sigfetcher_tx.into(),
             sigfetcher_thread,
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -98,7 +98,7 @@ addr = "127.0.0.1:8332"
         let (bitcoind_tx, bitcoind_rx) = mpsc::channel();
         let (sigfetcher_tx, sigfetcher_rx) = mpsc::channel();
 
-        let bitcoind_thread = Arc::from(RwLock::from(thread::spawn(move || {
+        let _ = Arc::from(RwLock::from(thread::spawn(move || {
             for msg in bitcoind_rx {
                 match msg {
                     BitcoindMessageOut::Shutdown => return,
@@ -106,7 +106,7 @@ addr = "127.0.0.1:8332"
                 }
             }
         })));
-        let sigfetcher_thread = Arc::from(RwLock::from(thread::spawn(move || {
+        let _ = Arc::from(RwLock::from(thread::spawn(move || {
             for msg in sigfetcher_rx {
                 match msg {
                     SigFetcherMessageOut::Shutdown => return,
@@ -117,9 +117,7 @@ addr = "127.0.0.1:8332"
         RpcUtils {
             revaultd,
             bitcoind_conn: BitcoindSender::from(bitcoind_tx),
-            bitcoind_thread,
             sigfetcher_conn: sigfetcher_tx.into(),
-            sigfetcher_thread,
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ pub mod test_utils {
         threadmessages::{
             BitcoindMessageOut, BitcoindSender, BitcoindThread, SigFetcherMessageOut,
         },
-        RpcUtils,
+        DaemonControl,
     };
     use revault_tx::bitcoin::{
         util::bip32::ChildNumber, Amount, OutPoint, Transaction as BitcoinTransaction, Txid,
@@ -92,7 +92,7 @@ addr = "127.0.0.1:8332"
 
     // Get a dummy handle for the RPC calls.
     // FIXME: we could do something cleaner at some point
-    pub fn dummy_rpcutil(datadir: PathBuf, role: UserRole) -> RpcUtils {
+    pub fn dummy_rpcutil(datadir: PathBuf, role: UserRole) -> DaemonControl {
         let revaultd = Arc::from(RwLock::from(dummy_revaultd(datadir, role)));
 
         let (bitcoind_tx, bitcoind_rx) = mpsc::channel();
@@ -114,7 +114,7 @@ addr = "127.0.0.1:8332"
             }
         })));
 
-        RpcUtils {
+        DaemonControl {
             revaultd,
             bitcoind_conn: BitcoindSender::from(bitcoind_tx),
             sigfetcher_conn: sigfetcher_tx.into(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,19 @@
+use revault_tx::bitcoin::Amount;
+
+use std::fmt;
+
+use serde::Serializer;
+
+/// Serialize a field as a string
+pub fn ser_to_string<T: fmt::Display, S: Serializer>(field: T, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_str(&field.to_string())
+}
+
+/// Serialize an amount as sats
+pub fn ser_amount<S: Serializer>(amount: &Amount, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_u64(amount.as_sat())
+}
+
 #[cfg(test)]
 pub mod test_utils {
     use crate::config::Config;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,19 +1,3 @@
-use revault_tx::bitcoin::Amount;
-
-use std::fmt;
-
-use serde::Serializer;
-
-/// Serialize a field as a string
-pub fn ser_to_string<T: fmt::Display, S: Serializer>(field: T, s: S) -> Result<S::Ok, S::Error> {
-    s.serialize_str(&field.to_string())
-}
-
-/// Serialize an amount as sats
-pub fn ser_amount<S: Serializer>(amount: &Amount, s: S) -> Result<S::Ok, S::Error> {
-    s.serialize_u64(amount.as_sat())
-}
-
 #[cfg(test)]
 pub mod test_utils {
     use crate::config::Config;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,6 @@ pub mod test_utils {
     use crate::{
         bitcoind::{interface::WalletTransaction, BitcoindError},
         database::interface::db_exec,
-        jsonrpc::UserRole,
         revaultd::{RevaultD, VaultStatus},
         threadmessages::{
             BitcoindMessageOut, BitcoindSender, BitcoindThread, SigFetcherMessageOut,
@@ -24,6 +23,13 @@ pub mod test_utils {
     };
 
     use rusqlite::params;
+
+    #[derive(Debug, Clone)]
+    pub enum UserRole {
+        Stakeholder,
+        Manager,
+        ManagerStakeholder,
+    }
 
     pub fn test_datadir() -> PathBuf {
         static mut COUNTER: u64 = 0;


### PR DESCRIPTION
This moves the implementation of the RPC commands from `jsonrpc/api/mod.rs` to a new `command` module, where it can then be exposed as a Rust interface for a downstream application (such as the GUI) to use in place of the JSONRPC-across-UDS which became clumsy since we made `revaultd` a library. This is a followup to https://github.com/revault/revaultd/pull/344, but does not remove the Windows code just yet.

An effort was put on documentation, and bikeshedding on the API is very welcome.
Unfortunately the PR is very convoluted but cleaning it up at this point would require a week.. Hopefully `--color-moved=zebra` can help at least a tiny bit, still.

It's still not final but i wanted to open this PR early to get feedback on the API.