### PR TITLE
Drop Windows support for JSONRPC over UDS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,5 +38,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
           profile: minimal
-      - name: Test on Rust ${{ matrix.toolchain }}
+      - name: Test on Rust ${{ matrix.toolchain }} (only Windows)
+        if: matrix.os == 'windows-latest'
+        run: cargo test --verbose --no-default-features
+      - name: Test on Rust ${{ matrix.toolchain }} (non Windows)
+        if: matrix.os != 'windows-latest'
         run: cargo test --verbose --color always -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,12 +185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,47 +411,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -476,15 +433,6 @@ checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
  "redox_syscall",
-]
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -533,7 +481,6 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
- "uds_windows",
 ]
 
 [[package]]
@@ -665,7 +612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795dd7aeeee24468e5a32661f6d27f7b5cbed802031b2d7640c7b10f8fb2dd50"
 dependencies = [
  "byteorder",
- "rand_core 0.5.1",
+ "rand_core",
  "rustc_version",
  "sodiumoxide",
  "subtle",
@@ -701,32 +648,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand",
- "remove_dir_all",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "uds_windows"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486992108df0fe0160680af1941fe856c521be931d5a5ecccefe0de86dc47e4a"
-dependencies = [
- "tempdir",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,16 @@ exclude = [".github/", ".cirrus.yml", "tests/",  "test_data/", "contrib/", "pypr
 [[bin]]
 name = "revaultd"
 path = "src/bin/daemon.rs"
+required-features = ["jsonrpc_server"]
 
 [[bin]]
 name = "revault-cli"
 path = "src/bin/cli.rs"
+required-features = ["jsonrpc_server"]
+
+[features]
+default = ["jsonrpc_server"]
+jsonrpc_server = ["jsonrpc-core", "jsonrpc-derive", "mio"]
 
 [dependencies]
 revault_tx = { git = "https://github.com/revault/revault_tx", features = ["use-serde"] }
@@ -54,6 +60,6 @@ rusqlite = { version = "0.26.3", features = ["bundled", "unlock_notify"] }
 libc = "0.2.80"
 
 # For the JSONRPC server
-jsonrpc-core = "15.1"
-jsonrpc-derive = "15.1"
-mio = { version = "0.7", features = ["default", "os-poll", "os-util", "uds"] }
+jsonrpc-core = { version = "15.1", optional = true }
+jsonrpc-derive = { version = "15.1", optional = true }
+mio = { version = "0.7", features = ["default", "os-poll", "os-util", "uds"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,4 @@ libc = "0.2.80"
 # For the JSONRPC server
 jsonrpc-core = "15.1"
 jsonrpc-derive = "15.1"
-[target.'cfg(not(windows))'.dependencies]
 mio = { version = "0.7", features = ["default", "os-poll", "os-util", "uds"] }
-[target.'cfg(windows)'.dependencies]
-uds_windows = "1.0"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -9,10 +9,7 @@ use std::{
 
 use serde_json::Value as Json;
 
-#[cfg(not(windows))]
 use std::os::unix::net::UnixStream;
-#[cfg(windows)]
-use uds_windows::UnixStream;
 
 // Exits with error
 fn show_usage() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod commands;
 mod communication;
 pub mod config;
 mod database;
+#[cfg(not(windows))]
 mod jsonrpc;
 mod revaultd;
 mod sigfetcher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub mod commands;
 mod communication;
 pub mod config;
 mod database;
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "jsonrpc_server"))]
 mod jsonrpc;
 mod revaultd;
 mod sigfetcher;
@@ -146,8 +146,8 @@ impl DaemonControl {
         self.sigfetcher_conn.shutdown();
     }
 
-    // TODO: make it optional at compile time
     /// Start and bind the server to the configured UNIX socket
+    #[cfg(all(not(windows), feature = "jsonrpc_server"))]
     pub fn rpc_server_setup(&self) -> Result<jsonrpc::server::UnixListener, io::Error> {
         let socket_file = self.revaultd.read().unwrap().rpc_socket_file();
         jsonrpc::server::rpcserver_setup(socket_file)
@@ -260,8 +260,8 @@ impl DaemonHandle {
             .expect("Joining sigfetcher thread");
     }
 
-    // TODO: make it optional at compilation time
     /// Start the JSONRPC server and listen for commands until we are stopped
+    #[cfg(all(not(windows), feature = "jsonrpc_server"))]
     pub fn rpc_server(&self) -> Result<(), io::Error> {
         log::info!("Starting JSONRPC server");
 


### PR DESCRIPTION
Based on #353, which provides a way to access `revaultd`'s commands through a library API, this drops the support of our greatly hacky JSONRPC server on UDS socket for Windows >10.

This also makes the JSONRPC server an optional feature (activated by default).

Fixes #339 
Fixes #79
Fixes #27 