### PR TITLE
Batch the exchange of signatures with the watchtowers

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,21 +28,6 @@ task:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock
   before_cache_script: rm -rf $CARGO_HOME/registry/index
-  target_cache:
-    folder: target
-    fingerprint_script:
-      - rustc --version
-      - cat Cargo.lock
-  bitcoind_cache:
-    folder: $BITCOIND_DIR_NAME
-  coordinatord_cache:
-    folder: tests/servers/coordinatord
-    fingerprint_script:
-      - cd tests/servers/coordinatord && git rev-parse HEAD
-  cosignerd_cache:
-    folder: tests/servers/cosignerd
-    fingerprint_script:
-      - cd tests/servers/cosignerd && git rev-parse HEAD
 
   test_script: |
     set -xe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "revault_net"
 version = "0.2.1"
-source = "git+https://github.com/revault/revault_net#b90a09b8c6ce050edbfde2108c512f801bc42c68"
+source = "git+https://github.com/revault/revault_net#7b985bc729bb9c6a0e48f6361ce93f448bfd4283"
 dependencies = [
  "bitcoin",
  "log",

--- a/src/database/interface.rs
+++ b/src/database/interface.rs
@@ -234,7 +234,6 @@ impl TryFrom<&Row<'_>> for DbVault {
         let final_txid = row
             .get::<_, Option<Vec<u8>>>(12)?
             .map(|raw_txid| encode::deserialize(&raw_txid).expect("We only store valid txids"));
-        let emer_shared: bool = row.get(13)?;
 
         Ok(DbVault {
             id,
@@ -249,7 +248,6 @@ impl TryFrom<&Row<'_>> for DbVault {
             delegated_at,
             moved_at,
             final_txid,
-            emer_shared,
         })
     }
 }
@@ -321,7 +319,7 @@ pub fn db_unvaulted_vaults(
         ],
         |row| {
             let db_vault: DbVault = row.try_into()?;
-            let unvault_tx: Vec<u8> = row.get(14)?;
+            let unvault_tx: Vec<u8> = row.get(13)?;
             let unvault_tx = UnvaultTransaction::from_psbt_serialized(&unvault_tx)
                 .expect("We store it with as_psbt_serialized");
 
@@ -345,7 +343,7 @@ pub fn db_spending_vaults(
         ],
         |row| {
             let db_vault: DbVault = row.try_into()?;
-            let unvault_tx: Vec<u8> = row.get(14)?;
+            let unvault_tx: Vec<u8> = row.get(13)?;
             let unvault_tx = UnvaultTransaction::from_psbt_serialized(&unvault_tx)
                 .expect("We store it with as_psbt_serialized");
 
@@ -370,7 +368,7 @@ pub fn db_canceling_vaults(
         ],
         |row| {
             let db_vault: DbVault = row.try_into()?;
-            let cancel_tx: Vec<u8> = row.get(14)?;
+            let cancel_tx: Vec<u8> = row.get(13)?;
             let cancel_tx = CancelTransaction::from_psbt_serialized(&cancel_tx)
                 .expect("We store it with as_psbt_serialized");
 
@@ -395,7 +393,7 @@ pub fn db_emering_vaults(
         ],
         |row| {
             let db_vault: DbVault = row.try_into()?;
-            let emer_tx: Vec<u8> = row.get(14)?;
+            let emer_tx: Vec<u8> = row.get(13)?;
             let emer_tx = EmergencyTransaction::from_psbt_serialized(&emer_tx)
                 .expect("We store it with to_psbt_serialized");
 
@@ -420,7 +418,7 @@ pub fn db_unemering_vaults(
         ],
         |row| {
             let db_vault: DbVault = row.try_into()?;
-            let unemer_tx: Vec<u8> = row.get(14)?;
+            let unemer_tx: Vec<u8> = row.get(13)?;
             let unemer_tx = UnvaultEmergencyTransaction::from_psbt_serialized(&unemer_tx)
                 .expect("We store it with to_psbt_serialized");
 
@@ -626,7 +624,7 @@ pub fn db_vault_by_unvault_txid(
         params![txid.to_vec(), TransactionType::Unvault as u32],
         |row| {
             let db_vault: DbVault = row.try_into()?;
-            let offset = 14;
+            let offset = 13;
 
             // FIXME: there is probably a more extensible way to implement the from()s so we don't
             // have to change all those when adding a column
@@ -669,7 +667,7 @@ pub fn db_sig_missing(
         ],
         |row| {
             let db_vault: DbVault = row.try_into()?;
-            let db_tx: DbTransaction = db_tx_from_row(row, 14)?;
+            let db_tx: DbTransaction = db_tx_from_row(row, 13)?;
 
             if let Some(db_txs) = vault_map.get_mut(&db_vault) {
                 db_txs.push(db_tx);
@@ -841,7 +839,7 @@ pub fn db_vaults_from_spend(
         params![spend_txid.to_vec()],
         |row| {
             let db_vault: DbVault = row.try_into()?;
-            let txid: Txid = encode::deserialize(&row.get::<_, Vec<u8>>(14)?).expect("We store it");
+            let txid: Txid = encode::deserialize(&row.get::<_, Vec<u8>>(13)?).expect("We store it");
             db_vaults.insert(txid, db_vault);
             Ok(())
         },

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -45,8 +45,6 @@ CREATE TABLE wallets (
  * spending txid or the canceling txid out of a deposit outpoint.
  * It MUST be NOT NULL if status is 'spending', 'spent', 'canceling'
  * or 'canceled'.
- * The emer_shared field indicates wether we already shared the Emergency
- * transaction for this vault with the watchtower.
  */
 CREATE TABLE vaults (
     id INTEGER PRIMARY KEY NOT NULL,
@@ -62,7 +60,6 @@ CREATE TABLE vaults (
     delegated_at INTEGER,
     moved_at INTEGER,
     final_txid BLOB,
-    emer_shared BOOLEAN NOT NULL CHECK (emer_shared IN (0,1)),
     FOREIGN KEY (wallet_id) REFERENCES wallets (id)
         ON UPDATE RESTRICT
         ON DELETE RESTRICT
@@ -151,7 +148,6 @@ pub struct DbVault {
     pub delegated_at: Option<u32>,
     pub moved_at: Option<u32>,
     pub final_txid: Option<Txid>,
-    pub emer_shared: bool,
 }
 
 // FIXME: naming it "db transaction" was ambiguous..

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -140,9 +140,9 @@ addr = "127.0.0.1:8332"
             tx.execute(
             "INSERT INTO vaults ( \
                 wallet_id, status, blockheight, deposit_txid, deposit_vout, amount, derivation_index, \
-                funded_at, moved_at, final_txid, emer_shared \
+                funded_at, moved_at, final_txid \
             ) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 0)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 wallet_id,
                 status as u32,

--- a/tests/test_watchtowers.py
+++ b/tests/test_watchtowers.py
@@ -26,16 +26,6 @@ def test_wt_share_revocation_txs(revault_network, bitcoind):
             f"Registered a new vault at '{deposit}'",
         )
 
-    rn.activate_vault(v)
-    for stk in rn.stks():
-        stk.watchtower.wait_for_logs(
-            [
-                f"Got UnEmer transaction signatures for vault at '{deposit}'",
-                f"Got Cancel transaction signatures for vault at '{deposit}'."
-                " Now watching for Unvault broadcast.",
-            ]
-        )
-
 
 @pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
 def test_wt_policy(directory, revault_network, bitcoind):


### PR DESCRIPTION
As per https://github.com/revault/practical-revault/pull/115.
This greatly simplifies the implementation, too!