### PR TITLE
Add Deserialize macro to commands response

### DIFF
--- a/src/bitcoind/interface.rs
+++ b/src/bitcoind/interface.rs
@@ -22,7 +22,8 @@ use jsonrpc::{
     client::Client,
     simple_http::{Error as HttpError, SimpleHttpTransport},
 };
-use serde::Serialize;
+
+use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
 
 // The minimum deposit value according to revault_tx depends also on the unvault's
@@ -920,7 +921,7 @@ impl BitcoinD {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletTransaction {
     pub hex: String,
     #[serde(rename = "received_at")]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1446,7 +1446,7 @@ pub struct ListOnchainTxEntry {
 }
 
 /// Status of a Spend transaction
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ListSpendStatus {
     NonFinal,
@@ -1455,7 +1455,7 @@ pub enum ListSpendStatus {
 }
 
 /// Information about a Spend transaction
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListSpendEntry {
     pub deposit_outpoints: Vec<OutPoint>,
     pub psbt: SpendTransaction,
@@ -1472,7 +1472,7 @@ pub struct ServersStatuses {
 }
 
 /// The type of an accounting event.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum HistoryEventKind {
     #[serde(rename = "cancel")]
     Cancel,
@@ -1483,7 +1483,7 @@ pub enum HistoryEventKind {
 }
 
 /// An accounting event.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryEvent {
     pub kind: HistoryEventKind,
     pub date: u32,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -32,8 +32,8 @@ use crate::{
     DaemonControl, VERSION,
 };
 use utils::{
-    finalized_emer_txs, gethistory, listvaults_from_db, presigned_txs, ser_amount, ser_to_string,
-    serialize_option_tx_hex, vaults_from_deposits,
+    deser_amount_from_sats, deser_from_str, finalized_emer_txs, gethistory, listvaults_from_db,
+    presigned_txs, ser_amount, ser_to_string, serialize_option_tx_hex, vaults_from_deposits,
 };
 
 use revault_tx::{
@@ -1352,18 +1352,18 @@ impl DaemonControl {
 }
 
 /// Descriptors the daemon was configured with
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetInfoDescriptors {
-    #[serde(serialize_with = "ser_to_string")]
+    #[serde(serialize_with = "ser_to_string", deserialize_with = "deser_from_str")]
     pub deposit: DepositDescriptor,
-    #[serde(serialize_with = "ser_to_string")]
+    #[serde(serialize_with = "ser_to_string", deserialize_with = "deser_from_str")]
     pub unvault: UnvaultDescriptor,
-    #[serde(serialize_with = "ser_to_string")]
+    #[serde(serialize_with = "ser_to_string", deserialize_with = "deser_from_str")]
     pub cpfp: CpfpDescriptor,
 }
 
 /// Information about the current state of the daemon
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetInfoResult {
     pub version: String,
     pub network: Network,
@@ -1375,12 +1375,15 @@ pub struct GetInfoResult {
 }
 
 /// Information about a vault.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListVaultsEntry {
-    #[serde(serialize_with = "ser_amount")]
+    #[serde(
+        serialize_with = "ser_amount",
+        deserialize_with = "deser_amount_from_sats"
+    )]
     pub amount: Amount,
     pub blockheight: u32,
-    #[serde(serialize_with = "ser_to_string")]
+    #[serde(serialize_with = "ser_to_string", deserialize_with = "deser_from_str")]
     pub status: VaultStatus,
     pub txid: Txid,
     pub vout: u32,
@@ -1393,13 +1396,13 @@ pub struct ListVaultsEntry {
 }
 
 /// Information about all our current vaults.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListVaultsResult {
     pub vaults: Vec<ListVaultsEntry>,
 }
 
 /// Revocation transactions for a given vault
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RevocationTransactions {
     pub cancel_tx: CancelTransaction,
     pub emergency_tx: EmergencyTransaction,
@@ -1408,7 +1411,7 @@ pub struct RevocationTransactions {
 }
 
 /// A vault's presigned transaction.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VaultPresignedTransaction<T: RevaultTransaction> {
     pub psbt: T,
     // FIXME: is it really necessary?.. It's mostly contained in the PSBT already
@@ -1417,7 +1420,7 @@ pub struct VaultPresignedTransaction<T: RevaultTransaction> {
 }
 
 /// Information about a vault's presigned transactions.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListPresignedTxEntry {
     pub vault_outpoint: OutPoint,
     pub unvault: VaultPresignedTransaction<UnvaultTransaction>,
@@ -1429,7 +1432,7 @@ pub struct ListPresignedTxEntry {
 }
 
 /// Information about a vault's onchain transactions.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListOnchainTxEntry {
     pub vault_outpoint: OutPoint,
     pub deposit: WalletTransaction,
@@ -1443,7 +1446,7 @@ pub struct ListOnchainTxEntry {
 }
 
 /// Status of a Spend transaction
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ListSpendStatus {
     NonFinal,
@@ -1452,7 +1455,7 @@ pub enum ListSpendStatus {
 }
 
 /// Information about a Spend transaction
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ListSpendEntry {
     pub deposit_outpoints: Vec<OutPoint>,
     pub psbt: SpendTransaction,
@@ -1461,7 +1464,7 @@ pub struct ListSpendEntry {
 }
 
 /// Information about the configured servers.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServersStatuses {
     coordinator: ServerStatus,
     cosigners: Vec<ServerStatus>,
@@ -1480,7 +1483,7 @@ pub enum HistoryEventKind {
 }
 
 /// An accounting event.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct HistoryEvent {
     pub kind: HistoryEventKind,
     pub date: u32,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -198,7 +198,6 @@ impl DaemonControl {
         } = db_tip(&revaultd.db_file()).expect("Database must not be dead");
         let number_of_vaults = self
             .list_vaults(None, None)
-            .vaults
             .iter()
             .filter(|l| {
                 l.status != VaultStatus::Spent
@@ -226,14 +225,12 @@ impl DaemonControl {
     /// List the current vaults, optionally filtered by status and/or deposit outpoints.
     pub fn list_vaults(
         &self,
-        statuses: Option<Vec<VaultStatus>>,
-        deposit_outpoints: Option<Vec<OutPoint>>,
-    ) -> ListVaultsResult {
+        statuses: Option<&[VaultStatus]>,
+        deposit_outpoints: Option<&[OutPoint]>,
+    ) -> Vec<ListVaultsEntry> {
         let revaultd = self.revaultd.read().unwrap();
-        ListVaultsResult {
-            vaults: listvaults_from_db(&revaultd, statuses, deposit_outpoints)
-                .expect("Database must be available"),
-        }
+        listvaults_from_db(&revaultd, statuses, deposit_outpoints)
+            .expect("Database must be available")
     }
 
     /// Get the deposit address at the lowest still unused derivation index
@@ -1393,12 +1390,6 @@ pub struct ListVaultsEntry {
     pub secured_at: Option<u32>,
     pub delegated_at: Option<u32>,
     pub moved_at: Option<u32>,
-}
-
-/// Information about all our current vaults.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ListVaultsResult {
-    pub vaults: Vec<ListVaultsEntry>,
 }
 
 /// Revocation transactions for a given vault

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1341,7 +1341,7 @@ impl DaemonControl {
         start: u32,
         end: u32,
         limit: u64,
-        kind: Vec<HistoryEventKind>,
+        kind: &[HistoryEventKind],
     ) -> Result<Vec<HistoryEvent>, CommandError> {
         let revaultd = self.revaultd.read().unwrap();
         gethistory(&revaultd, &self.bitcoind_conn, start, end, limit, kind)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -860,7 +860,7 @@ impl DaemonControl {
     pub fn get_spend_tx(
         &self,
         outpoints: &[OutPoint],
-        destinations: BTreeMap<Address, u64>,
+        destinations: &BTreeMap<Address, u64>,
         feerate_vb: u64,
     ) -> Result<SpendTransaction, CommandError> {
         let revaultd = self.revaultd.read().unwrap();
@@ -894,11 +894,11 @@ impl DaemonControl {
         }
 
         let txos: Vec<SpendTxOut> = destinations
-            .into_iter()
+            .iter()
             .map(|(addr, value)| {
                 let script_pubkey = addr.script_pubkey();
                 SpendTxOut::new(TxOut {
-                    value,
+                    value: *value,
                     script_pubkey,
                 })
             })

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1482,6 +1482,16 @@ pub enum HistoryEventKind {
     Spend,
 }
 
+impl fmt::Display for HistoryEventKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Cancel => write!(f, "Cancel"),
+            Self::Deposit => write!(f, "Deposit"),
+            Self::Spend => write!(f, "Spend"),
+        }
+    }
+}
+
 /// An accounting event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryEvent {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1466,9 +1466,9 @@ pub struct ListSpendEntry {
 /// Information about the configured servers.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServersStatuses {
-    coordinator: ServerStatus,
-    cosigners: Vec<ServerStatus>,
-    watchtowers: Vec<ServerStatus>,
+    pub coordinator: ServerStatus,
+    pub cosigners: Vec<ServerStatus>,
+    pub watchtowers: Vec<ServerStatus>,
 }
 
 /// The type of an accounting event.

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -280,7 +280,7 @@ pub fn gethistory<T: BitcoindThread>(
     start: u32,
     end: u32,
     limit: u64,
-    kind: Vec<HistoryEventKind>,
+    kind: &[HistoryEventKind],
 ) -> Result<Vec<HistoryEvent>, CommandError> {
     let db_path = revaultd.db_file();
     // All vaults which have one transaction (either the funding, the canceling, the unvaulting, the spending)
@@ -1492,7 +1492,7 @@ mod tests {
             0,
             4,
             20,
-            vec![
+            &[
                 HistoryEventKind::Deposit,
                 HistoryEventKind::Cancel,
                 HistoryEventKind::Spend,
@@ -1539,7 +1539,7 @@ mod tests {
             0,
             2,
             20,
-            vec![
+            &[
                 HistoryEventKind::Deposit,
                 HistoryEventKind::Cancel,
                 HistoryEventKind::Spend,

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -93,8 +93,8 @@ where
 // FIXME: we could make this more efficient with smarter SQL queries
 pub fn listvaults_from_db(
     revaultd: &RevaultD,
-    statuses: Option<Vec<VaultStatus>>,
-    outpoints: Option<Vec<OutPoint>>,
+    statuses: Option<&[VaultStatus]>,
+    outpoints: Option<&[OutPoint]>,
 ) -> Result<Vec<ListVaultsEntry>, DatabaseError> {
     db_vaults(&revaultd.db_file()).map(|db_vaults| {
         db_vaults
@@ -896,8 +896,8 @@ mod tests {
         for v in &vaults {
             let res = &listvaults_from_db(
                 &revaultd,
-                Some(vec![v.db_vault.status]),
-                Some(vec![v.db_vault.deposit_outpoint]),
+                Some(&[v.db_vault.status]),
+                Some(&[v.db_vault.deposit_outpoint]),
             )
             .unwrap()[0];
             assert_eq!(res.amount, v.db_vault.amount);
@@ -914,7 +914,7 @@ mod tests {
         // Checking that filters work
         assert_eq!(listvaults_from_db(&revaultd, None, None).unwrap().len(), 4);
         assert_eq!(
-            listvaults_from_db(&revaultd, Some(vec![VaultStatus::Unconfirmed]), None)
+            listvaults_from_db(&revaultd, Some(&[VaultStatus::Unconfirmed]), None)
                 .unwrap()
                 .len(),
             1
@@ -922,8 +922,8 @@ mod tests {
         assert_eq!(
             listvaults_from_db(
                 &revaultd,
-                Some(vec![VaultStatus::Unconfirmed]),
-                Some(vec![vaults[1].db_vault.deposit_outpoint])
+                Some(&[VaultStatus::Unconfirmed]),
+                Some(&[vaults[1].db_vault.deposit_outpoint])
             )
             .unwrap()
             .len(),
@@ -933,7 +933,7 @@ mod tests {
             listvaults_from_db(
                 &revaultd,
                 None,
-                Some(vec![
+                Some(&[
                     vaults[0].db_vault.deposit_outpoint,
                     vaults[1].db_vault.deposit_outpoint
                 ])
@@ -945,7 +945,7 @@ mod tests {
         assert_eq!(
             listvaults_from_db(
                 &revaultd,
-                Some(vec![
+                Some(&[
                     VaultStatus::Unconfirmed,
                     VaultStatus::Funded,
                     VaultStatus::Secured
@@ -959,7 +959,7 @@ mod tests {
         assert_eq!(
             listvaults_from_db(
                 &revaultd,
-                Some(vec![
+                Some(&[
                     VaultStatus::Unconfirmed,
                     VaultStatus::Funded,
                     VaultStatus::Secured,

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -18,7 +18,7 @@ use revault_tx::{
 
 use std::{collections::BTreeMap, fmt};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// The kind of signature the WT refused
 #[derive(Debug)]
@@ -306,7 +306,7 @@ pub fn get_presigs(
     Ok(resp.signatures)
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ServerStatus {
     pub host: String,
     pub reachable: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,7 +83,7 @@ pub struct BitcoindConfig {
     pub poll_interval_secs: Duration,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ScriptsConfig {
     #[serde(deserialize_with = "deserialize_fromstr")]
     pub deposit_descriptor: DepositDescriptor,
@@ -126,7 +126,7 @@ pub struct ManagerConfig {
 }
 
 /// Static informations we require to operate
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     /// Everything we need to know to talk to bitcoind
     pub bitcoind_config: BitcoindConfig,

--- a/src/jsonrpc/api/mod.rs
+++ b/src/jsonrpc/api/mod.rs
@@ -496,7 +496,9 @@ impl RpcApi for RpcImpl {
         end: u32,
         limit: u64,
     ) -> jsonrpc_core::Result<serde_json::Value> {
-        let events = meta.daemon_control.get_history(start, end, limit, kind)?;
+        let events = meta
+            .daemon_control
+            .get_history(start, end, limit, kind.as_ref())?;
         Ok(json!({
             "events": events,
         }))

--- a/src/jsonrpc/api/mod.rs
+++ b/src/jsonrpc/api/mod.rs
@@ -319,8 +319,10 @@ impl RpcApi for RpcImpl {
             None
         };
 
-        let res = meta.daemon_control.list_vaults(statuses, outpoints);
-        Ok(json!(res))
+        let res = meta
+            .daemon_control
+            .list_vaults(statuses.as_deref(), outpoints.as_deref());
+        Ok(json!({ "vaults": res }))
     }
 
     fn getdepositaddress(

--- a/src/jsonrpc/api/mod.rs
+++ b/src/jsonrpc/api/mod.rs
@@ -424,7 +424,7 @@ impl RpcApi for RpcImpl {
 
         let tx = meta
             .daemon_control
-            .get_spend_tx(&outpoints, destinations, feerate_vb)?;
+            .get_spend_tx(&outpoints, &destinations, feerate_vb)?;
         Ok(json!({
             "spend_tx": tx,
         }))

--- a/src/revaultd.rs
+++ b/src/revaultd.rs
@@ -102,7 +102,7 @@ impl TryFrom<u32> for VaultStatus {
 }
 
 impl FromStr for VaultStatus {
-    type Err = ();
+    type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -122,7 +122,7 @@ impl FromStr for VaultStatus {
             "unvaultemergencyvaulted" => Ok(Self::UnvaultEmergencyVaulted),
             "spending" => Ok(Self::Spending),
             "spent" => Ok(Self::Spent),
-            _ => Err(()),
+            _ => Err(format!("Unknown status: {}", s)),
         }
     }
 }


### PR DESCRIPTION
Clients importing the revaultd lib and consuming
the jsonrpc API need to deserialize the commands
responses.

This commit introduces new deserialization helpers
and adds them to commands structs fields.