### PR TITLE
Poller reorg cleanup

### DIFF
--- a/src/bitcoind/poller.rs
+++ b/src/bitcoind/poller.rs
@@ -159,7 +159,6 @@ fn mark_confirmed_spends(
                     &spend_txid,
                     e
                 );
-                continue;
             }
         };
 
@@ -276,7 +275,6 @@ fn mark_confirmed_cancels(
                     &cancel_txid,
                     e
                 );
-                continue;
             }
         };
 
@@ -333,7 +331,6 @@ fn mark_confirmed_unemers(
                     &unemer_txid,
                     e
                 );
-                continue;
             }
         };
 
@@ -395,7 +392,6 @@ fn mark_confirmed_emers(
                     &emer_txid,
                     e
                 );
-                continue;
             }
         };
 

--- a/src/database/actions.rs
+++ b/src/database/actions.rs
@@ -214,22 +214,15 @@ pub fn setup_db(revaultd: &mut RevaultD) -> Result<(), DatabaseError> {
     Ok(())
 }
 
-pub fn db_update_tip_dbtx(
-    db_tx: &rusqlite::Transaction,
-    tip: &BlockchainTip,
-) -> Result<(), DatabaseError> {
-    db_tx
-        .execute(
-            "UPDATE tip SET blockheight = (?1), blockhash = (?2)",
-            params![tip.height, tip.hash.to_vec()],
-        )
-        .map_err(|e| DatabaseError(format!("Inserting new tip: {}", e.to_string())))
-        .map(|_| ())
-}
-
 /// Set the current best block hash and height
 pub fn db_update_tip(db_path: &Path, tip: &BlockchainTip) -> Result<(), DatabaseError> {
-    db_exec(db_path, |db_tx| db_update_tip_dbtx(db_tx, tip))
+    db_exec(db_path, |db_tx| {
+        db_tx.execute(
+            "UPDATE tip SET blockheight = (?1), blockhash = (?2)",
+            params![tip.height, tip.hash.to_vec()],
+        )?;
+        Ok(())
+    })
 }
 
 pub fn db_update_deposit_index(

--- a/src/database/interface.rs
+++ b/src/database/interface.rs
@@ -587,23 +587,6 @@ pub fn db_cancel_transaction(
     .map(|mut rows| rows.pop())
 }
 
-/// Get the Cancel transaction corresponding to this vault
-pub fn db_cancel_dbtx(
-    db_tx: &Transaction,
-    vault_id: u32,
-) -> Result<Option<CancelTransaction>, DatabaseError> {
-    db_query_tx(
-        db_tx,
-        "SELECT * FROM presigned_transactions WHERE vault_id = (?1) AND type = (?2)",
-        params![vault_id, TransactionType::Cancel as u32],
-        |row| row.try_into(),
-    )
-    .map(|mut rows| {
-        rows.pop()
-            .map(|db_tx: DbTransaction| db_tx.psbt.assert_cancel())
-    })
-}
-
 /// Get the Emergency transaction corresponding to this vault.
 ///
 /// NOTE: the transaction *might* not be here even if you polled the vault status

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -337,8 +337,8 @@ def test_reorged_unvault(revault_network, bitcoind):
         w.wait_for_logs(
             [
                 "Detected reorg",
-                f"{deposits[0]}.* Unvault transaction is still confirmed .*'{unvault_tx_a['blockheight']}'",
-                f"{deposits[1]}.* Unvault transaction is still confirmed .*'{unvault_tx_b['blockheight']}'",
+                f"{deposits[0]}.* First Stage transaction is still confirmed .*'{unvault_tx_a['blockheight']}'",
+                f"{deposits[1]}.* First Stage transaction is still confirmed .*'{unvault_tx_b['blockheight']}'",
                 "Rescan .*done",
                 f"New tip.* {new_tip}",
             ]
@@ -496,8 +496,8 @@ def test_reorged_spend(revault_network, bitcoind):
         w.wait_for_logs(
             [
                 "Detected reorg",
-                f"Vault {deposits[0]}'s Spend transaction .* got unconfirmed",
-                f"Vault {deposits[1]}'s Spend transaction .* got unconfirmed",
+                f"Vault {deposits[0]}'s Spend transaction got unconfirmed",
+                f"Vault {deposits[1]}'s Spend transaction got unconfirmed",
                 "Rescan of all vaults in db done.",
             ]
         )
@@ -549,7 +549,7 @@ def test_reorged_cancel(revault_network, bitcoind):
         w.wait_for_logs(
             [
                 "Detected reorg",
-                f"Vault {deposit}'s Cancel transaction .* got unconfirmed",
+                f"Vault {deposit}'s Cancel transaction got unconfirmed",
                 "Rescan of all vaults in db done.",
             ]
         )
@@ -561,7 +561,7 @@ def test_reorged_cancel(revault_network, bitcoind):
         w.wait_for_logs(
             [
                 "Detected reorg",
-                f"Vault {deposit}'s Cancel transaction .* got unconfirmed",
+                f"Vault {deposit}'s Cancel transaction got unconfirmed",
                 "Rescan of all vaults in db done.",
             ]
         )


### PR DESCRIPTION
This is a followup to #366 which cleans up the reorg logic, trying to make the code paths easier to follow. It then removes all RPC calls from within the DB transaction used to rewind the state (:tada:). Finally it adds a more thorough test for the timestamp fields as requested in #366 and includes a couple drive-by cleanups.