### PR TITLE
Remove the `hex` field from `listpresignedtxs`

### DIFF
--- a/contrib/recompile_tests_servers.sh
+++ b/contrib/recompile_tests_servers.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+# From the root of the repository, recompiles all the servers submodules at
+# the commit of the current branch. Assumes `cargo`.
+
+git submodule update --init --recursive
+
+for s in $(ls tests/servers/); do
+    cd tests/servers/$s
+    cargo build
+    cd ../../../
+done

--- a/doc/API.md
+++ b/doc/API.md
@@ -188,21 +188,13 @@ vault's state).
 
 #### Presigned txs
 
-| Field               | Type                                                           | Description                                                              |
-| ------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `vault_outpoint`    | [presigned_tx](#presigned-tx)                                  | The vault deposit transaction outpoint.                                  |
-| `unvault`           | [presigned_tx](#presigned-tx)                                  | The Unvaulting transaction                                               |
-| `cancel`            | [presigned_tx](#presigned-tx)                                  | The Cancel transaction                                                   |
-| `emergency`         | [presigned_tx](#presigned-tx)                                  | The Emergency transaction, or `null` if we are not a stakeholder         |
-| `unvault_emergency` | [presigned_tx](#presigned-tx)                                  | The Unvault Emergency transaction, or `null` if we are not a stakeholder |
-
-
-#### Presigned tx
-
-| Field    | Type                     | Description                                                                      |
-| -------- | ------------------------ | -------------------------------------------------------------------------------- |
-| `psbt`   | string                   | The presigned transaction as a base64-encoded PSBT                               |
-| `hex`    | string or `null`         | If fully-signed, the presigned transaction as a hex-encoded Bitcoin transaction  |
+| Field               | Type     | Description                                                                                    |
+| ------------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `vault_outpoint`    | string   | The vault deposit transaction outpoint.                                                        |
+| `unvault`           | string   | The Unvaulting transaction PSBT (base64 encoded)                                               |
+| `cancel`            | string   | The Cancel transaction PSBT (base64 encoded)                                                   |
+| `emergency`         | string   | The Emergency transaction PSBT (base64 encoded), or `null` if we are not a stakeholder         |
+| `unvault_emergency` | string   | The Unvault Emergency transaction PSBT (base64 encoded), or `null` if we are not a stakeholder |
 
 
 ### `listonchaintransactions`

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 use utils::{
     deser_amount_from_sats, deser_from_str, finalized_emer_txs, gethistory, listvaults_from_db,
-    presigned_txs, ser_amount, ser_to_string, serialize_option_tx_hex, vaults_from_deposits,
+    presigned_txs, ser_amount, ser_to_string, vaults_from_deposits,
 };
 
 use revault_tx::{
@@ -1474,25 +1474,16 @@ pub struct RevocationTransactions {
     pub emergency_unvault_tx: UnvaultEmergencyTransaction,
 }
 
-/// A vault's presigned transaction.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct VaultPresignedTransaction<T: RevaultTransaction> {
-    pub psbt: T,
-    // FIXME: is it really necessary?.. It's mostly contained in the PSBT already
-    #[serde(rename(serialize = "hex"), serialize_with = "serialize_option_tx_hex")]
-    pub transaction: Option<BitcoinTransaction>,
-}
-
 /// Information about a vault's presigned transactions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListPresignedTxEntry {
     pub vault_outpoint: OutPoint,
-    pub unvault: VaultPresignedTransaction<UnvaultTransaction>,
-    pub cancel: VaultPresignedTransaction<CancelTransaction>,
+    pub unvault: UnvaultTransaction,
+    pub cancel: CancelTransaction,
     /// Always None if not stakeholder
-    pub emergency: Option<VaultPresignedTransaction<EmergencyTransaction>>,
+    pub emergency: Option<EmergencyTransaction>,
     /// Always None if not stakeholder
-    pub unvault_emergency: Option<VaultPresignedTransaction<UnvaultEmergencyTransaction>>,
+    pub unvault_emergency: Option<UnvaultEmergencyTransaction>,
 }
 
 /// Information about a vault's onchain transactions.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,8 @@ pytest==6.2
 pytest-xdist==1.31.0
 pytest-timeout==1.3.4
 ephemeral_port_reserve==1.1.1
-bip32~=2.1
+bip32~=3.0
+bip380==0.0.3
 psycopg2-binary==2.9
 pynacl==1.4
 

--- a/tests/test_framework/serializations.py
+++ b/tests/test_framework/serializations.py
@@ -401,9 +401,9 @@ class CTxOut(object):
 
 
 class CScriptWitness(object):
-    def __init__(self):
+    def __init__(self, stack=[]):
         # stack is a vector of strings
-        self.stack = []
+        self.stack = stack
 
     def __repr__(self):
         return "CScriptWitness(%s)" % (
@@ -417,8 +417,8 @@ class CScriptWitness(object):
 
 
 class CTxInWitness(object):
-    def __init__(self):
-        self.scriptWitness = CScriptWitness()
+    def __init__(self, script=CScriptWitness()):
+        self.scriptWitness = script
 
     def deserialize(self, f):
         self.scriptWitness.stack = deser_string_vector(f)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -121,19 +121,18 @@ def test_raw_broadcast_cancel(revault_network, bitcoind):
         revault_network.secure_vault(vault)
         revault_network.activate_vault(vault)
 
-        unvault_tx = stks[0].rpc.listpresignedtransactions([deposit])[
-            "presigned_transactions"
-        ][0]["unvault"]["hex"]
+        unvault_tx = revault_network.signed_unvault_psbt(
+            deposit, vault["derivation_index"]
+        )
         txid = bitcoind.rpc.sendrawtransaction(unvault_tx)
         bitcoind.generate_block(1, wait_for_mempool=txid)
 
         for w in stks + mans:
             wait_for(lambda: len(w.rpc.listvaults(["unvaulted"], [deposit])) == 1)
 
-        cancel_tx = stks[0].rpc.listpresignedtransactions([deposit])[
-            "presigned_transactions"
-        ][0]["cancel"]["hex"]
-        logging.debug(f"{cancel_tx}")
+        cancel_tx = revault_network.signed_cancel_psbt(
+            deposit, vault["derivation_index"]
+        )
         txid = bitcoind.rpc.sendrawtransaction(cancel_tx)
         bitcoind.generate_block(1, wait_for_mempool=txid)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -282,7 +282,7 @@ def test_sigfetcher_secured_vaults(revault_network, bitcoind):
         wait_for(
             lambda: stk.rpc.listpresignedtransactions([outpoint])[
                 "presigned_transactions"
-            ][0]["unvault"]["psbt"]
+            ][0]["unvault"]
             == unvault_psbt
         )
 
@@ -330,7 +330,7 @@ def get_unvault_txids(wallet, vaults):
         unvault_psbt = serializations.PSBT()
         unvault_b64 = wallet.rpc.listpresignedtransactions([deposit])[
             "presigned_transactions"
-        ][0]["unvault"]["psbt"]
+        ][0]["unvault"]
         unvault_psbt.deserialize(unvault_b64)
         unvault_psbt.tx.calc_sha256()
         unvault_txids.append(unvault_psbt.tx.hash)

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -29,9 +29,9 @@ def test_getinfo(revaultd_manager, bitcoind):
     assert res["managers_threshold"] == 3
     assert res["participant_type"] == "manager"
     # test descriptors: RPC call & which Revaultd's were configured
-    assert res["descriptors"]["cpfp"] == revaultd_manager.cpfp_desc
-    assert res["descriptors"]["deposit"] == revaultd_manager.deposit_desc
-    assert res["descriptors"]["unvault"] == revaultd_manager.unvault_desc
+    assert res["descriptors"]["cpfp"] == str(revaultd_manager.cpfp_desc)
+    assert res["descriptors"]["deposit"] == str(revaultd_manager.deposit_desc)
+    assert res["descriptors"]["unvault"] == str(revaultd_manager.unvault_desc)
 
     wait_for(lambda: revaultd_manager.rpc.call("getinfo")["blockheight"] > 0)
     height = revaultd_manager.rpc.call("getinfo")["blockheight"]


### PR DESCRIPTION
It was redundant, and needlessly added complexity and computation. 

Based on #367. Only the last commit is part of this PR.