### PR TITLE
Pinning click to fix CI issues.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: rustfmt
         run: cargo fmt -- --check
       - name: black (Python linter)
-        run: pip install --version black==22.1.0 && black --check tests/
+        run: pip install --version black==22.1.0 click==8.0.4 && black --check tests/
 
   unit_tests:
     needs: linter


### PR DESCRIPTION
As suggested in https://github.com/psf/black/issues/2964, the `click` version has been pinned to `8.0.4`.