### PR TITLE
Add cpfp and change index getonchaintransactions

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -228,12 +228,14 @@ network (hence they may be unconfirmed). Will error if any of the vaults is unkn
 
 #### Wallet tx
 
-| Field         | Type          | Description                                                                   |
-| ------------- | ------------- | ----------------------------------------------------------------------------  |
-| `blockheight` | int or `null` | Height of the block containing the transaction, `null` if unconfirmed         |
-| `blocktime`   | int or `null` | Timestamp of the block containing the transaction, `null` if unconfirmed      |
-| `hex`         | string        | Hexadecimal of the network-serialized transaction                             |
-| `received_at` | int           | Transaction reception date as the number of seconds since UNIX epoch          |
+| Field          | Type          | Description                                                                  |
+| -------------- | ------------- | ---------------------------------------------------------------------------- |
+| `blockheight`  | int or `null` | Height of the block containing the transaction, `null` if unconfirmed        |
+| `blocktime`    | int or `null` | Timestamp of the block containing the transaction, `null` if unconfirmed     |
+| `change_index` | int or `null` | Index of the change output, `null` if not present                            |
+| `cpfp_index`   | int or `null` | Index of the cpfp output, `null` if not present                              |
+| `hex`          | string        | Hexadecimal of the network-serialized transaction                            |
+| `received_at`  | int           | Transaction reception date as the number of seconds since UNIX epoch         |
 
 
 ### `getrevocationtxs`

--- a/src/database/interface.rs
+++ b/src/database/interface.rs
@@ -894,6 +894,19 @@ pub fn db_cpfpable_unvaults(db_path: &Path) -> Result<Vec<UnvaultTransaction>, D
     )
 }
 
+/// This function returns the vaults that have the common final tx with the given txid.
+pub fn db_vaults_with_final_txid(
+    db_path: &Path,
+    txid: &Txid,
+) -> Result<Vec<DbVault>, DatabaseError> {
+    db_query(
+        db_path,
+        "SELECT * FROM vaults WHERE final_txid = (?1)",
+        params![txid.to_vec()],
+        |row| row.try_into(),
+    )
+}
+
 /// This function returns the vaults that are deposit, change deposit or spend output of
 /// a limited number of tx which occured between two dates.
 pub fn db_vaults_with_txids_in_period(


### PR DESCRIPTION
Raw hex transactions give not enough information about
the UTXO recipients. We introduce in this commit two more fields
to the list items: change_index and cpfp_index, respectively
the indexes of the change output and cpfp output in a transaction.

A cpfp output is an UTXO with a script pubkey derived from the CPFP descriptor.
A change output is an UTXO with a script pubkey derived from the Deposit
descriptor.

It adds a test (in relation to #300) 