### PR TITLE
Merging in `update_spend_tx`.

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -349,7 +349,7 @@ feerate.
 ### `updatespendtx`
 
 The `updatespendtx` RPC Command stores or update the stored Spend transaction with the
-given one.
+given one. The signatures from both the old & the new transactions will be merged.
 
 #### Request
 


### PR DESCRIPTION
Currently, `update_spend_tx` over-writes the partial signatures that are present in the database with the signatures of the given `spend_tx`. To avoid this, the suggested change in #312  was to merge the older and the newer signatures together and save it in the database. 

The corresponding test and the API documentation have been updated with the same