### PR TITLE
Add new fields to ListSpendTxEntry

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -410,6 +410,7 @@ You'll have to manually fetch the vaults statuses if you want to know, for examp
 | `psbt`              | string        | Base64-encoded Spend transaction PSBT                                |
 | `change_index`      | integer       | Index of the change output, might be null                            |
 | `cpfp_index`        | integer       | Index of the CPFP outputs                                            |
+| `status`            | string        | [Spend status](#spend_status)                                        |
 
 `change_index` and `cpfp_index` indicate the index of the change (if any) and CPFP outputs in the outputs array as created by `getspendtransaction`. This does not aim to tag all the outputs paying to either a CPFP or a Deposit descriptor, as that would be impossible to guarantee. If two outputs pay to the change, the index of the last one will be returned. If two outputs pay to the CPFP address, the index of the first one will be returned.
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -405,14 +405,16 @@ Please note that this status refers only to the Spend transaction, with regardin
 
 ##### Spend transaction resources
 
-| Field               | Type         | Description                                                                                             |
-| ------------------- | ------------ | ------------------------------------------------------------------------------------------------------- |
-| `deposit_outpoints` | string array | Array of the deposit outpoints of the vaults this transaction spends                                    |
-| `deposit_amount`    | integer      | Total amount in satoshis of the vaults this transaction spends                                          |
-| `psbt`              | string       | Base64-encoded Spend transaction PSBT                                                                   |
-| `change_index`      | integer      | Index of the change output, might be null                                                               |
-| `cpfp_index`        | integer      | Index of the CPFP outputs                                                                               |
-| `status`            | string       | [Spend status](#spend-status)                                                                           |
+
+| Field               | Type         | Description                                                                                                                       |
+| ------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `deposit_outpoints` | string array | Array of the deposit outpoints of the vaults this transaction spends                                                              |
+| `deposit_amount`    | integer      | Total amount in satoshis of the vaults this transaction spends                                                                    |
+| `cpfp_amount`       | integer      | Total amount in satoshis of the unvault txs and the spend tx cpfp outputs allocated as operational budget for the managers        |
+| `psbt`              | string       | Base64-encoded Spend transaction PSBT                                                                                             |
+| `change_index`      | integer      | Index of the change output, might be null                                                                                         |
+| `cpfp_index`        | integer      | Index of the CPFP outputs                                                                                                         |
+| `status`            | string       | [Spend status](#spend-status)                                                                                                     |
 
 `change_index` and `cpfp_index` indicate the index of the change (if any) and CPFP outputs in the outputs array as created by `getspendtransaction`. This does not aim to tag all the outputs paying to either a CPFP or a Deposit descriptor, as that would be impossible to guarantee. If two outputs pay to the change, the index of the last one will be returned. If two outputs pay to the CPFP address, the index of the first one will be returned.
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -388,13 +388,14 @@ disregarded for forward compatibility.
 ##### Spend status
 
 Please note that this status refers only to the Spend transaction, with regarding to the signatures and the broadcast status.
-You'll have to manually fetch the vaults statuses if you want to know, for example, if the vault was canceled or not.
 
-| Value           | Description                                                                                                                                                                              |
+| Value           | Description                                                                                      |
 | --------------- | ------------------------------------------------------------------------------------------------ |
 | `non_final`     | The Spend transaction is not final, we are awaiting signatures either from managers or cosigners |
 | `pending`       | The transaction is not broadcasted to the Bitcoin network                                        |
 | `broadcasted`   | The Spend transaction has been broadcasted                                                       |
+| `confirmed`     | The Spend transaction has been confirmed in the blockchain                                       |
+| `deprecated`    | The Spend transaction cannot be used anymore, one of its input was spent by another transaction  |
 
 #### Response
 
@@ -404,14 +405,14 @@ You'll have to manually fetch the vaults statuses if you want to know, for examp
 
 ##### Spend transaction resources
 
-| Field               | Type          | Description                                                          |
-| ------------------- | ------------- | -------------------------------------------------------------------- |
-| `deposit_outpoints` | string array  | Array of the deposit outpoints of the vaults this transaction spends |
-| `deposit_amount`    | integer       | Total amount in satoshis of the vaults this transaction spends      |
-| `psbt`              | string        | Base64-encoded Spend transaction PSBT                                |
-| `change_index`      | integer       | Index of the change output, might be null                            |
-| `cpfp_index`        | integer       | Index of the CPFP outputs                                            |
-| `status`            | string        | [Spend status](#spend_status)                                        |
+| Field               | Type         | Description                                                                                             |
+| ------------------- | ------------ | ------------------------------------------------------------------------------------------------------- |
+| `deposit_outpoints` | string array | Array of the deposit outpoints of the vaults this transaction spends                                    |
+| `deposit_amount`    | integer      | Total amount in satoshis of the vaults this transaction spends                                          |
+| `psbt`              | string       | Base64-encoded Spend transaction PSBT                                                                   |
+| `change_index`      | integer      | Index of the change output, might be null                                                               |
+| `cpfp_index`        | integer      | Index of the CPFP outputs                                                                               |
+| `status`            | string       | [Spend status](#spend-status)                                                                           |
 
 `change_index` and `cpfp_index` indicate the index of the change (if any) and CPFP outputs in the outputs array as created by `getspendtransaction`. This does not aim to tag all the outputs paying to either a CPFP or a Deposit descriptor, as that would be impossible to guarantee. If two outputs pay to the change, the index of the last one will be returned. If two outputs pay to the CPFP address, the index of the first one will be returned.
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -407,6 +407,7 @@ You'll have to manually fetch the vaults statuses if you want to know, for examp
 | Field               | Type          | Description                                                          |
 | ------------------- | ------------- | -------------------------------------------------------------------- |
 | `deposit_outpoints` | string array  | Array of the deposit outpoints of the vaults this transaction spends |
+| `deposit_amount`    | integer       | Total amount in satoshis of the vaults this transaction spends      |
 | `psbt`              | string        | Base64-encoded Spend transaction PSBT                                |
 | `change_index`      | integer       | Index of the change output, might be null                            |
 | `cpfp_index`        | integer       | Index of the CPFP outputs                                            |


### PR DESCRIPTION
Client needs more information to display to the user, specially related to the current status and deprecation of the tx.
This PR adds new fields to ListSpendTxEntry:

**`status`**:
`listspendtx` accepts a spend tx status to filter its response,
but it did not share in ListSpendTxEntry the status of each spend.

**`deposit_amount`**:
Psbt of the spend transaction is consuming
unvault outputs and do not contains information
about the total amount of the vaults moved.
Then Api client needs to retrieve for each spend transaction
the vaults to calculate the total.
Because the command is already retrieving the vaults
to get the outpoints, the calcul can be done at this level.

**`cpfp_amount`**:
Total amount of the cpfp outputs of the unvault txs and the spend tx.
Amount allocated to managers for operational budget.

**`deprecated`**
True if the spend tx has a vault consumed

**new status: `confirmed`**
When the spend tx is in the blockchain and confirmed