### PR TITLE
Skip tests if postgres has not been setup.

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -538,6 +538,7 @@ def test_batched_cpfp_transaction(revault_network, bitcoind):
     wait_for(lambda: len(man.rpc.listvaults(["spent"])["vaults"]) == len(vaults))
 
 
+@pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
 def test_rbfed_cpfp_transaction(revault_network, bitcoind):
     """We don't have explicit RBF logic, but since we signal for it we should
     be able to replace a previous CPFP with a higher-fee, higher-feerate one.

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -182,6 +182,7 @@ def test_getrevocationtxs(revault_network, bitcoind):
         assert txs == n.rpc.getrevocationtxs(deposit)
 
 
+@pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
 def test_getunvaulttx(revault_network):
     revault_network.deploy(3, 1)
     mans = revault_network.mans()
@@ -589,6 +590,7 @@ def test_revocationtxs(revault_network):
     assert len(stks[0].rpc.listvaults(["securing"], [deposit])["vaults"]) == 1
 
 
+@pytest.mark.skipif(not POSTGRES_IS_SETUP, reason="Needs Postgres for servers db")
 def test_unvaulttx(revault_network):
     """Sanity checks for the unvaulttx command"""
     revault_network.deploy(3, 1)


### PR DESCRIPTION
This is a cherry-pick of the first commit of #389.

This bug was also reported by @Zshan0 on IRC. Thanks @rndhouse for the fix!