### PR TITLE
Change getspendtx response of ListSpendtxEntry

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -341,9 +341,9 @@ feerate.
 
 #### Response
 
-| Field      | Type   | Description                                     |
-| ---------- | ------ | ----------------------------------------------- |
-| `spend_tx` | string | Base64-encoded Spend transaction PSBT           |
+| Field      | Type                                                        | Description                    |
+| ---------- | ----------------------------------------------------------- | ------------------------------ |
+| `spend_tx` | [Spend transaction resources](#spend_transaction_resources) | Spend transaction informations |
 
 
 ### `updatespendtx`
@@ -401,7 +401,7 @@ Please note that this status refers only to the Spend transaction, with regardin
 
 | Field          | Type   | Description                                                          |
 | -------------- | ------ | -------------------------------------------------------------------- |
-| `spend_txs`    | array  | Array of [Spend transaction resources](#spend_transaction_reources)  |
+| `spend_txs`    | array  | Array of [Spend transaction resources](#spend_transaction_resources) |
 
 ##### Spend transaction resources
 

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -676,7 +676,7 @@ def test_retrieve_vault_status(revault_network, bitcoind):
     revault_network.activate_vault(vault)
     deposits = [f"{vault['txid']}:{vault['vout']}"]
     destinations = {bitcoind.rpc.getnewaddress(): vault["amount"] // 2}
-    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]
+    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]["psbt"]
     for m in [man] + mans:
         spend_tx = m.man_keychain.sign_spend_psbt(spend_tx, [vault["derivation_index"]])
         mans[0].rpc.updatespendtx(spend_tx)
@@ -719,7 +719,7 @@ def test_retrieve_vault_status(revault_network, bitcoind):
     revault_network.activate_vault(vault)
     deposits = [f"{vault['txid']}:{vault['vout']}"]
     destinations = {bitcoind.rpc.getnewaddress(): vault["amount"] // 2}
-    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]
+    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]["psbt"]
     for m in [man] + mans:
         spend_tx = m.man_keychain.sign_spend_psbt(spend_tx, [vault["derivation_index"]])
         mans[0].rpc.updatespendtx(spend_tx)
@@ -759,7 +759,7 @@ def test_retrieve_vault_status(revault_network, bitcoind):
     revault_network.activate_vault(vault)
     deposits = [f"{vault['txid']}:{vault['vout']}"]
     destinations = {bitcoind.rpc.getnewaddress(): vault["amount"] // 2}
-    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]
+    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]["psbt"]
     for m in [man] + mans:
         spend_tx = m.man_keychain.sign_spend_psbt(spend_tx, [vault["derivation_index"]])
         mans[0].rpc.updatespendtx(spend_tx)
@@ -800,7 +800,7 @@ def test_retrieve_vault_status(revault_network, bitcoind):
     revault_network.activate_vault(vault)
     deposits = [f"{vault['txid']}:{vault['vout']}"]
     destinations = {bitcoind.rpc.getnewaddress(): vault["amount"] // 2}
-    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]
+    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]["psbt"]
     for m in [man] + mans:
         spend_tx = m.man_keychain.sign_spend_psbt(spend_tx, [vault["derivation_index"]])
         mans[0].rpc.updatespendtx(spend_tx)
@@ -842,7 +842,7 @@ def test_retrieve_vault_status(revault_network, bitcoind):
     revault_network.activate_vault(vault)
     deposits = [f"{vault['txid']}:{vault['vout']}"]
     destinations = {bitcoind.rpc.getnewaddress(): vault["amount"] // 2}
-    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]
+    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]["psbt"]
     for m in [man] + mans:
         spend_tx = m.man_keychain.sign_spend_psbt(spend_tx, [vault["derivation_index"]])
         mans[0].rpc.updatespendtx(spend_tx)
@@ -876,7 +876,7 @@ def test_retrieve_vault_status(revault_network, bitcoind):
     revault_network.activate_vault(vault)
     deposits = [f"{vault['txid']}:{vault['vout']}"]
     destinations = {bitcoind.rpc.getnewaddress(): vault["amount"] // 2}
-    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]
+    spend_tx = mans[0].rpc.getspendtx(deposits, destinations, 1)["spend_tx"]["psbt"]
     for m in [man] + mans:
         spend_tx = m.man_keychain.sign_spend_psbt(spend_tx, [vault["derivation_index"]])
         mans[0].rpc.updatespendtx(spend_tx)

--- a/tests/test_framework/revault_network.py
+++ b/tests/test_framework/revault_network.py
@@ -608,7 +608,9 @@ class RevaultNetwork:
             deriv_indexes.append(v["derivation_index"])
         man.wait_for_active_vaults(deposits)
 
-        spend_tx = man.rpc.getspendtx(deposits, destinations, feerate)["spend_tx"]
+        spend_tx = man.rpc.getspendtx(deposits, destinations, feerate)["spend_tx"][
+            "psbt"
+        ]
         for man in self.mans():
             spend_tx = man.man_keychain.sign_spend_psbt(spend_tx, deriv_indexes)
             man.rpc.updatespendtx(spend_tx)
@@ -654,7 +656,9 @@ class RevaultNetwork:
         for man in self.mans():
             man.wait_for_active_vaults(deposits)
 
-        spend_tx = man.rpc.getspendtx(deposits, destinations, feerate)["spend_tx"]
+        spend_tx = man.rpc.getspendtx(deposits, destinations, feerate)["spend_tx"][
+            "psbt"
+        ]
         for man in self.mans():
             spend_tx = man.man_keychain.sign_spend_psbt(spend_tx, deriv_indexes)
             man.rpc.updatespendtx(spend_tx)


### PR DESCRIPTION
for https://github.com/revault/revault-gui/issues/358
Some information are needed.
User cannot use listspendtx because at this step of the spend tx creation, the transaction is not yet saved in the database