### PR TITLE
`sighash_type`  made explicit along with a bump in `bitcoind` version for CI testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ task:
     VERBOSE: 0
     LOG_LEVEL: debug
     TIMEOUT: 300
-    BITCOIND_VERSION: 22.0
+    BITCOIND_VERSION: 23.0
     BITCOIND_DIR_NAME: "bitcoin-$BITCOIND_VERSION"
   matrix:
     - name: 'Misc functional tests'

--- a/src/bitcoind/interface.rs
+++ b/src/bitcoind/interface.rs
@@ -726,7 +726,11 @@ impl BitcoinD {
     pub fn sign_psbt(&self, psbt: &Psbt) -> Result<(bool, Psbt), BitcoindError> {
         let res = self.make_cpfp_request(
             "walletprocesspsbt",
-            &params!(Json::String(base64::encode(&encode::serialize(psbt)))),
+            &params!(
+                Json::String(base64::encode(&encode::serialize(psbt))),
+                Json::Bool(true),
+                Json::String("ALL".to_string()),
+            ),
         )?;
         let complete = res
             .get("complete")


### PR DESCRIPTION
Since the Bitcoin Core ignores the sighash type specified inside the PSBT inputs, `sign_psbt` relied on the default value of `sighash_type` which aligned with our requirements. https://github.com/bitcoin/bitcoin/pull/22514 changed the default value from `SIGHASH_ALL` to `SIGHASH_DEFAULT`. Making `sighash_type` explicit fixes the minor breaking change caused by the update in the bitcoin wallet. Note that since `sighashtype` parameter comes after the `sign` parameter, the value of `sign` has been set to the default value, `true`. 

Along with the fix, `bitcoind` version used in CI has been bumped from `22.0` to `23.0`. 

This issue closes #414.